### PR TITLE
feat: use D-Bus API for 802.1X enterprise auth instead of file writing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,17 +149,7 @@ You do not have the required permissions. Ensure you are part of the appropriate
             }
 
             Event::ConfigureNewEapNetwork(network_name) => {
-                if unsafe { libc::geteuid() } != 0 {
-                    let _ = Notification::send(
-                        "impala must be run as root to configure WPA Entreprise networks"
-                            .to_string(),
-                        notification::NotificationLevel::Info,
-                        &tui.events.sender.clone(),
-                    );
-
-                    continue;
-                }
-                app.auth.init_eap(network_name);
+                app.auth.init_eap(network_name, Some(app.client.clone()));
                 app.focused_block = impala_nm::app::FocusedBlock::WpaEntrepriseAuth;
             }
 

--- a/src/mode/station/auth.rs
+++ b/src/mode/station/auth.rs
@@ -1,6 +1,8 @@
 pub mod entreprise;
 pub mod psk;
 
+use std::sync::Arc;
+
 use crate::mode::station::auth::{
     entreprise::{
         WPAEntreprise,
@@ -11,6 +13,7 @@ use crate::mode::station::auth::{
     },
     psk::Psk,
 };
+use crate::nm::NMClient;
 
 #[derive(Debug, Default)]
 pub struct Auth {
@@ -22,8 +25,8 @@ pub struct Auth {
 }
 
 impl Auth {
-    pub fn init_eap(&mut self, network_name: String) {
-        self.eap = Some(WPAEntreprise::new(network_name));
+    pub fn init_eap(&mut self, network_name: String, client: Option<Arc<NMClient>>) {
+        self.eap = Some(WPAEntreprise::new(network_name, client));
     }
 
     pub fn reset(&mut self) {

--- a/src/mode/station/auth/entreprise/eduroam.rs
+++ b/src/mode/station/auth/entreprise/eduroam.rs
@@ -111,6 +111,14 @@ impl Eduroam {
         self.state.selected().is_some()
     }
 
+    pub fn get_identity(&self) -> String {
+        self.identity.field.value().to_string()
+    }
+
+    pub fn get_phase2_password(&self) -> String {
+        self.phase2_password.field.value().to_string()
+    }
+
     pub fn apply(&mut self) -> Result<()> {
         self.validate()?;
         let mut file = OpenOptions::new()

--- a/src/mode/station/auth/entreprise/peap.rs
+++ b/src/mode/station/auth/entreprise/peap.rs
@@ -180,6 +180,38 @@ impl PEAP {
         self.state.selected().is_some()
     }
 
+    pub fn get_identity(&self) -> String {
+        self.identity.field.value().to_string()
+    }
+
+    pub fn get_ca_cert(&self) -> Option<String> {
+        let val = self.ca_cert.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_client_cert(&self) -> Option<String> {
+        let val = self.client_cert.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_client_key(&self) -> Option<String> {
+        let val = self.client_key.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_key_passphrase(&self) -> Option<String> {
+        let val = self.key_passphrase.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_phase2_method(&self) -> String {
+        self.phase2_method.to_string().to_lowercase()
+    }
+
+    pub fn get_phase2_password(&self) -> String {
+        self.phase2_password.field.value().to_string()
+    }
+
     pub fn apply(&mut self, network_name: &str) -> Result<()> {
         self.validate()?;
 

--- a/src/mode/station/auth/entreprise/pwd.rs
+++ b/src/mode/station/auth/entreprise/pwd.rs
@@ -99,6 +99,14 @@ impl PWD {
         self.state.selected().is_some()
     }
 
+    pub fn get_identity(&self) -> String {
+        self.identity.field.value().to_string()
+    }
+
+    pub fn get_password(&self) -> String {
+        self.password.field.value().to_string()
+    }
+
     pub fn apply(&mut self, network_name: &str) -> Result<()> {
         self.validate()?;
 

--- a/src/mode/station/auth/entreprise/tls.rs
+++ b/src/mode/station/auth/entreprise/tls.rs
@@ -163,6 +163,27 @@ impl TLS {
         self.state.selected().is_some()
     }
 
+    pub fn get_identity(&self) -> String {
+        self.identity.field.value().to_string()
+    }
+
+    pub fn get_ca_cert(&self) -> String {
+        self.ca_cert.field.value().to_string()
+    }
+
+    pub fn get_client_cert(&self) -> String {
+        self.client_cert.field.value().to_string()
+    }
+
+    pub fn get_client_key(&self) -> String {
+        self.client_key.field.value().to_string()
+    }
+
+    pub fn get_key_passphrase(&self) -> Option<String> {
+        let val = self.key_passphrase.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
     pub fn apply(&mut self, network_name: &str) -> Result<()> {
         self.validate()?;
 

--- a/src/mode/station/auth/entreprise/ttls.rs
+++ b/src/mode/station/auth/entreprise/ttls.rs
@@ -173,6 +173,38 @@ impl TTLS {
         self.state.selected().is_some()
     }
 
+    pub fn get_identity(&self) -> String {
+        self.identity.field.value().to_string()
+    }
+
+    pub fn get_ca_cert(&self) -> Option<String> {
+        let val = self.ca_cert.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_client_cert(&self) -> Option<String> {
+        let val = self.client_cert.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_client_key(&self) -> Option<String> {
+        let val = self.client_key.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_key_passphrase(&self) -> Option<String> {
+        let val = self.key_passphrase.field.value();
+        if val.is_empty() { None } else { Some(val.to_string()) }
+    }
+
+    pub fn get_phase2_method(&self) -> String {
+        self.phase2_method.to_string().to_lowercase().replace("tunneled", "")
+    }
+
+    pub fn get_phase2_password(&self) -> String {
+        self.phase2_password.field.value().to_string()
+    }
+
     pub fn apply(&mut self, network_name: &str) -> Result<()> {
         self.validate()?;
 


### PR DESCRIPTION
closes #7 

1. Removed the root check for 802.1X enterprise networks
  2. Added add_enterprise_connection D-Bus method to NMClient
  3. Updated enterprise auth (TLS, TTLS, PEAP, PWD, Eduroam) to use D-Bus instead of file writing
  4. NetworkManager/PolicyKit will now handle authorization (may prompt for password)