### PR TITLE
feat/ethernet

### DIFF
--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -522,9 +522,9 @@ impl Station {
                 let signal_str = format!("{}%", signal_percent);
 
                 // Don't show WiFi connected icon when Ethernet is the primary connection
-                if !is_ethernet {
-                    if let Some(connected_net) = &self.connected_network {
-                        if connected_net.name == net.name {
+                if !is_ethernet
+                    && let Some(connected_net) = &self.connected_network
+                        && connected_net.name == net.name {
                             let row = vec![
                                 Line::from("󰖩 ").centered(),
                                 Line::from(known.name.clone()).centered(),
@@ -537,8 +537,6 @@ impl Station {
 
                             return Row::new(row);
                         }
-                    }
-                }
 
                 let row = vec![
                     Line::from("").centered(),

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -587,9 +587,9 @@ impl NMClient {
         for conn_path in active_connections {
             if let Ok(info) = self.get_active_connection_info(conn_path.as_str()).await {
                 // Get the connection settings to check the type
-                if let Ok(settings) = self.get_connection_settings(&info.connection_path).await {
-                    if let Some(connection) = settings.get("connection") {
-                        if let Some(conn_type) = connection.get("type") {
+                if let Ok(settings) = self.get_connection_settings(&info.connection_path).await
+                    && let Some(connection) = settings.get("connection")
+                        && let Some(conn_type) = connection.get("type") {
                             let type_str: String = conn_type.try_clone()?.try_into()?;
                             // 802-3-ethernet is the NetworkManager type for wired connections
                             if type_str == "802-3-ethernet"
@@ -598,8 +598,6 @@ impl NMClient {
                                 return Ok(true);
                             }
                         }
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
this closes #18 

- **feat(nm.mod): check if there is an active ethernet connection**
- **feat(mode.station): show ethernet icon to display ethernet is primary connection**
- **fix: fmt station**
- **fix: apply clippy**
