### PR TITLE
Update nixpkgs input version to 25.11 to fix nix run/shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
 
   outputs =
     { self, nixpkgs }:


### PR DESCRIPTION
The `tui-qrcode` dependency requires `rustc` version 1.87.0 or higher, but Nixpkgs 25.05's default `rustc` version is 1.86.0. 

Bumping it to 25.11 fixes the issue and allows people to ephemerally run this without having to pass `--override-inputs nixpkgs <newer nixpkgs>`.

Users _can_ override `rustc` or just add a `inputs.nixpkgs.follows = "nixpkgs"` when installing this as part of their own flake, but on the CLI it's a bit cumbersome.