### PR TITLE
Basic update to flake.lock to fix nix run/shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749494155,
-        "narHash": "sha256-FG4DEYBpROupu758beabUk9lhrblSf5hnv84v1TLqMc=",
+        "lastModified": 1776434932,
+        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88331c17ba434359491e8d5889cce872464052c2",
+        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
Nix run/shell fail with:
```
❯❯ nix shell github:aashish-thapa/wlctl
error:
       … while updating the lock file of flake 'github:aashish-thapa/wlctl/2b52131a75ef3b26af8fc165a5c03625110e85af'

       error: cannot write modified lock file of flake 'github:aashish-thapa/wlctl' (use '--no-write-lock-file' to ignore)
```

Trivial fix by updating flake.lock