### PR TITLE
fix: resolve clippy 1.95 lint errors

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -55,10 +55,10 @@ impl EventHandler {
                   }
                   Some(Ok(evt)) = crossterm_event => {
                     match evt {
-                      CrosstermEvent::Key(key) => {
-                        if key.kind == crossterm::event::KeyEventKind::Press {
-                          sender_cloned.send(Event::Key(key)).unwrap();
-                        }
+                      CrosstermEvent::Key(key)
+                        if key.kind == crossterm::event::KeyEventKind::Press =>
+                      {
+                        sender_cloned.send(Event::Key(key)).unwrap();
                       },
                       CrosstermEvent::Resize(x, y) => {
                         sender_cloned.send(Event::Resize(x, y)).unwrap();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -149,22 +149,16 @@ pub async fn handle_key_events(
             KeyCode::Esc if app.config.esc_quit => {
                 app.quit();
             }
-            KeyCode::Char('c' | 'C') => {
-                if key_event.modifiers == KeyModifiers::CONTROL {
-                    app.quit();
-                }
+            KeyCode::Char('c' | 'C') if key_event.modifiers == KeyModifiers::CONTROL => {
+                app.quit();
             }
 
-            KeyCode::Char('j') | KeyCode::Down => {
-                if app.reset.selected_mode == Mode::Station {
-                    app.reset.selected_mode = Mode::Ap;
-                }
+            KeyCode::Char('j') | KeyCode::Down if app.reset.selected_mode == Mode::Station => {
+                app.reset.selected_mode = Mode::Ap;
             }
 
-            KeyCode::Char('k') | KeyCode::Up => {
-                if app.reset.selected_mode == Mode::Ap {
-                    app.reset.selected_mode = Mode::Station;
-                }
+            KeyCode::Char('k') | KeyCode::Up if app.reset.selected_mode == Mode::Ap => {
+                app.reset.selected_mode = Mode::Station;
             }
 
             KeyCode::Enter => {
@@ -178,10 +172,8 @@ pub async fn handle_key_events(
 
     if !app.device.is_powered {
         match app.focused_block {
-            FocusedBlock::AdapterInfos => {
-                if key_event.code == KeyCode::Esc {
-                    app.focused_block = FocusedBlock::Device;
-                }
+            FocusedBlock::AdapterInfos if key_event.code == KeyCode::Esc => {
+                app.focused_block = FocusedBlock::Device;
             }
 
             FocusedBlock::Device => match key_event.code {
@@ -192,10 +184,8 @@ pub async fn handle_key_events(
                     app.quit();
                 }
 
-                KeyCode::Char('c' | 'C') => {
-                    if key_event.modifiers == KeyModifiers::CONTROL {
-                        app.quit();
-                    }
+                KeyCode::Char('c' | 'C') if key_event.modifiers == KeyModifiers::CONTROL => {
+                    app.quit();
                 }
 
                 KeyCode::Char(c) if c == config.device.infos => {
@@ -711,34 +701,34 @@ pub async fn handle_key_events(
                                     KeyCode::Enter | KeyCode::Char(' ') => {
                                         toggle_connect(app, sender).await?
                                     }
-                                    KeyCode::Char('j') | KeyCode::Down => {
-                                        if !station.new_networks.is_empty() {
-                                            let i = match station.new_networks_state.selected() {
-                                                Some(i) => {
-                                                    let limit = if station.show_hidden_networks {
-                                                        station.new_networks.len()
-                                                            + station.new_hidden_networks.len()
-                                                            - 1
-                                                    } else {
-                                                        station.new_networks.len() - 1
-                                                    };
-                                                    if i < limit { i + 1 } else { i }
-                                                }
-                                                None => 0,
-                                            };
+                                    KeyCode::Char('j') | KeyCode::Down
+                                        if !station.new_networks.is_empty() =>
+                                    {
+                                        let i = match station.new_networks_state.selected() {
+                                            Some(i) => {
+                                                let limit = if station.show_hidden_networks {
+                                                    station.new_networks.len()
+                                                        + station.new_hidden_networks.len()
+                                                        - 1
+                                                } else {
+                                                    station.new_networks.len() - 1
+                                                };
+                                                if i < limit { i + 1 } else { i }
+                                            }
+                                            None => 0,
+                                        };
 
-                                            station.new_networks_state.select(Some(i));
-                                        }
+                                        station.new_networks_state.select(Some(i));
                                     }
-                                    KeyCode::Char('k') | KeyCode::Up => {
-                                        if !station.new_networks.is_empty() {
-                                            let i = match station.new_networks_state.selected() {
-                                                Some(i) => i.saturating_sub(1),
-                                                None => 0,
-                                            };
+                                    KeyCode::Char('k') | KeyCode::Up
+                                        if !station.new_networks.is_empty() =>
+                                    {
+                                        let i = match station.new_networks_state.selected() {
+                                            Some(i) => i.saturating_sub(1),
+                                            None => 0,
+                                        };
 
-                                            station.new_networks_state.select(Some(i));
-                                        }
+                                        station.new_networks_state.select(Some(i));
                                     }
                                     _ => {}
                                 },

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -395,7 +395,7 @@ impl NMClient {
         }
 
         // Sort by timestamp (most recent first)
-        wifi_connections.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        wifi_connections.sort_by_key(|c| std::cmp::Reverse(c.timestamp));
 
         Ok(wifi_connections)
     }

--- a/src/nm/wifi.rs
+++ b/src/nm/wifi.rs
@@ -28,7 +28,7 @@ impl NMClient {
         }
 
         // Sort by signal strength (strongest first)
-        networks.sort_by(|a, b| b.strength.cmp(&a.strength));
+        networks.sort_by_key(|n| std::cmp::Reverse(n.strength));
 
         Ok(networks)
     }


### PR DESCRIPTION
## Summary
- Fix `collapsible_match` errors in `event.rs` and `handler.rs` by converting nested `if` blocks into match guards
- Fix `unnecessary_sort_by` errors in `nm/wifi.rs` and `nm/mod.rs` by using `sort_by_key` with `std::cmp::Reverse`

These lints became `-D warnings` errors on clippy 1.95 and were blocking CI on `main`.

Logic is preserved: all outer matches have `_ => {}` catch-alls, so guard-failed arms fall through to no-ops (same net behavior as the prior nested-`if` no-ops). The sort changes preserve descending stable-sort semantics.

## Test plan
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (11 tests)
- [x] `cargo build --release` succeeds