### PR TITLE
feat: support multiple wireless adapters

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,8 @@
 use anyhow::{Result, anyhow};
+use ratatui::widgets::Row;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
+use zbus::zvariant::OwnedObjectPath;
 
 use crate::nm::{Mode, NMClient};
 
@@ -9,6 +11,9 @@ use crate::{
     event::Event, mode::station::auth::Auth, mode::station::network::Network,
     notification::Notification, reset::Reset,
 };
+
+/// Marker glyph rendered in the Active column for the currently active adapter.
+const ACTIVE_MARKER: &str = "●";
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FocusedBlock {
@@ -30,6 +35,107 @@ pub enum FocusedBlock {
     Doctor,
 }
 
+/// A lightweight handle to a WiFi adapter known to NetworkManager.
+///
+/// Holding the path + human name avoids re-fetching the interface name every
+/// render and lets the Device block list adapters without instantiating a full
+/// `Device` per row.
+#[derive(Debug, Clone)]
+pub struct AdapterSummary {
+    pub path: OwnedObjectPath,
+    pub name: String,
+}
+
+impl AdapterSummary {
+    async fn fetch(client: &NMClient, path: OwnedObjectPath) -> Result<Self> {
+        let name = client.get_device_interface(path.as_str()).await?;
+        Ok(Self { path, name })
+    }
+
+    async fn fetch_all(client: &NMClient) -> Result<Vec<Self>> {
+        let paths = client.get_wifi_devices().await?;
+        let mut out = Vec::with_capacity(paths.len());
+        for p in paths {
+            out.push(Self::fetch(client, p).await?);
+        }
+        Ok(out)
+    }
+}
+
+/// Snapshot of adapter state passed to render paths. Bundles the list plus
+/// both cursors so Device / Station / AP views can render a consistent
+/// multi-row adapter list without each re-computing selection logic.
+pub struct AdapterView<'a> {
+    pub adapters: &'a [AdapterSummary],
+    pub active_index: usize,
+    pub selection_index: usize,
+}
+
+impl<'a> AdapterView<'a> {
+    /// Number of adapter rows visible in the Device block before the table
+    /// starts scrolling. Keeping this fixed means the layout footprint does
+    /// not shift when adapters are plugged in or out.
+    pub const VISIBLE_ROWS: u16 = 2;
+
+    /// Non-data rows the Device block reserves: top border + bottom border
+    /// + header row + header bottom margin.
+    const CHROME_ROWS: u16 = 4;
+
+    /// Total height callers should use for the Device block. Constant so
+    /// `TableState` can scroll the viewport for 3+ adapters without the
+    /// surrounding layout shifting.
+    pub const BLOCK_HEIGHT: u16 = Self::VISIBLE_ROWS + Self::CHROME_ROWS;
+
+    pub fn count(&self) -> usize {
+        self.adapters.len()
+    }
+
+    pub fn is_multi(&self) -> bool {
+        self.adapters.len() > 1
+    }
+
+    /// Index the Table's `TableState` should highlight. Selection cursor is
+    /// only meaningful while the Device block has focus and more than one
+    /// adapter exists; otherwise snap to the active row.
+    pub fn table_selection(&self, focused: FocusedBlock) -> usize {
+        if focused == FocusedBlock::Device && self.is_multi() {
+            self.selection_index
+        } else {
+            self.active_index
+        }
+    }
+
+    pub fn is_active(&self, index: usize) -> bool {
+        index == self.active_index
+    }
+
+    /// Builds one Row per adapter. `active` receives the marker string and
+    /// `inactive` does not — this keeps the "●" glyph in one place and lets
+    /// each render path supply its own mode-specific column set.
+    pub fn build_rows<'r, F, G>(&self, active: F, inactive: G) -> Vec<Row<'r>>
+    where
+        F: Fn(&AdapterSummary, &str) -> Row<'r>,
+        G: Fn(&AdapterSummary) -> Row<'r>,
+    {
+        if !self.is_multi() {
+            let only = &self.adapters[self.active_index];
+            return vec![active(only, ACTIVE_MARKER)];
+        }
+
+        self.adapters
+            .iter()
+            .enumerate()
+            .map(|(idx, a)| {
+                if self.is_active(idx) {
+                    active(a, ACTIVE_MARKER)
+                } else {
+                    inactive(a)
+                }
+            })
+            .collect()
+    }
+}
+
 pub struct App {
     pub running: bool,
     pub focused_block: FocusedBlock,
@@ -37,6 +143,9 @@ pub struct App {
     pub client: Arc<NMClient>,
     pub adapter: Adapter,
     pub device: Device,
+    pub adapters: Vec<AdapterSummary>,
+    pub active_index: usize,
+    pub adapter_selection_index: usize,
     pub agent: AuthAgent,
     pub reset: Reset,
     pub config: Arc<Config>,
@@ -69,7 +178,13 @@ Error: {}",
             }
         };
 
-        let mut device = Device::new(client.clone()).await?;
+        let adapters = AdapterSummary::fetch_all(&client).await?;
+        if adapters.is_empty() {
+            return Err(anyhow!("No WiFi device found"));
+        }
+
+        let active_index = 0;
+        let mut device = Device::new(client.clone(), adapters[active_index].path.clone()).await?;
 
         let adapter =
             match Adapter::new(client.clone(), device.device_path.clone(), config.clone()).await {
@@ -79,22 +194,11 @@ Error: {}",
                 }
             };
 
-        // Set the initial mode
         device.set_mode(mode).await?;
 
         let agent = AuthAgent::new(sender);
-        // Note: NetworkManager handles authentication differently than iwd
-        // Secrets are managed via NetworkManager's SecretAgent interface
-        // For now, we'll handle password prompts through the existing agent mechanism
 
-        let focused_block = if device.is_powered {
-            match device.mode {
-                Mode::Station => FocusedBlock::KnownNetworks,
-                Mode::Ap => FocusedBlock::AccessPoint,
-            }
-        } else {
-            FocusedBlock::Device
-        };
+        let focused_block = Self::default_focus_for(&device);
 
         let reset = Reset::new(mode);
 
@@ -107,6 +211,9 @@ Error: {}",
             agent,
             reset,
             device,
+            adapters,
+            active_index,
+            adapter_selection_index: active_index,
             config,
             auth: Auth::default(),
             network_name_requiring_auth: None,
@@ -114,6 +221,72 @@ Error: {}",
             doctor: None,
             doctor_run_id: 0,
         })
+    }
+
+    pub fn adapter_count(&self) -> usize {
+        self.adapters.len()
+    }
+
+    /// Moves the visual adapter selection without touching the active adapter.
+    /// Wraps around and is a no-op with <=1 adapter so callers don't need to guard.
+    pub fn move_adapter_selection(&mut self, delta: isize) {
+        let len = self.adapters.len();
+        if len <= 1 {
+            return;
+        }
+        self.adapter_selection_index =
+            (self.adapter_selection_index as isize + delta).rem_euclid(len as isize) as usize;
+    }
+
+    /// Activates the adapter currently highlighted by the selection cursor.
+    /// No-op when the selection already points at the active adapter.
+    pub async fn activate_selected_adapter(&mut self) -> Result<()> {
+        if self.adapter_selection_index == self.active_index {
+            return Ok(());
+        }
+
+        let target = self
+            .adapters
+            .get(self.adapter_selection_index)
+            .ok_or_else(|| anyhow!("Selected adapter out of range"))?
+            .path
+            .clone();
+        let previous_mode = self.device.mode;
+
+        self.activate_device(target, previous_mode).await?;
+        self.active_index = self.adapter_selection_index;
+        Ok(())
+    }
+
+    fn default_focus_for(device: &Device) -> FocusedBlock {
+        if device.is_powered {
+            match device.mode {
+                Mode::Station => FocusedBlock::KnownNetworks,
+                Mode::Ap => FocusedBlock::AccessPoint,
+            }
+        } else {
+            FocusedBlock::Device
+        }
+    }
+
+    // Builds a Device + Adapter for the given path and only commits them to `self`
+    // after every await has succeeded. Callers update `active_index`/`adapters`
+    // after this returns Ok, so `self` stays consistent on failure.
+    async fn activate_device(&mut self, path: OwnedObjectPath, preserve_mode: Mode) -> Result<()> {
+        let mut new_device = Device::new(self.client.clone(), path).await?;
+        new_device.set_mode(preserve_mode).await?;
+        let new_adapter = Adapter::new(
+            self.client.clone(),
+            new_device.device_path.clone(),
+            self.config.clone(),
+        )
+        .await?;
+
+        self.device = new_device;
+        self.adapter = new_adapter;
+        self.focused_block = Self::default_focus_for(&self.device);
+
+        Ok(())
     }
 
     pub async fn reset(mode: Mode) -> Result<()> {
@@ -124,7 +297,13 @@ Error: {}",
             }
         };
 
-        let mut device = match Device::new(client.clone()).await {
+        let device_paths = client.get_wifi_devices().await?;
+        let path = device_paths
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("No WiFi device found"))?;
+
+        let mut device = match Device::new(client.clone(), path).await {
             Ok(v) => v,
             Err(e) => return Err(anyhow!("Can not access the NetworkManager service: {}", e)),
         };
@@ -136,6 +315,47 @@ Error: {}",
     pub async fn tick(&mut self) -> Result<()> {
         self.notifications.retain(|n| n.ttl > 0);
         self.notifications.iter_mut().for_each(|n| n.ttl -= 1);
+
+        // Refresh the adapter list; if the active path disappeared, fall back to
+        // the first remaining device. `adapters` is only committed after any
+        // fallible activation so `self` stays consistent on error.
+        let current = AdapterSummary::fetch_all(&self.client).await?;
+        let paths_changed = current.len() != self.adapters.len()
+            || current
+                .iter()
+                .zip(&self.adapters)
+                .any(|(a, b)| a.path != b.path);
+
+        if paths_changed {
+            // Remember which path the user was browsing so we can keep the
+            // cursor on it across reorders / insertions when it still exists.
+            let prev_selection_path = self
+                .adapters
+                .get(self.adapter_selection_index)
+                .map(|a| a.path.clone());
+
+            let active_path = self.device.device_path.clone();
+            match current.iter().position(|a| a.path.as_str() == active_path) {
+                Some(idx) => {
+                    self.active_index = idx;
+                    self.adapters = current;
+                }
+                None => {
+                    if current.is_empty() {
+                        return Err(anyhow!("No WiFi device found"));
+                    }
+                    let previous_mode = self.device.mode;
+                    let fallback = current[0].path.clone();
+                    self.activate_device(fallback, previous_mode).await?;
+                    self.active_index = 0;
+                    self.adapters = current;
+                }
+            }
+
+            self.adapter_selection_index = prev_selection_path
+                .and_then(|p| self.adapters.iter().position(|a| a.path == p))
+                .unwrap_or(self.active_index);
+        }
 
         self.device.refresh().await?;
         self.adapter.refresh().await?;

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,6 @@
-use anyhow::Context;
 use anyhow::Result;
 use std::sync::Arc;
+use zbus::zvariant::OwnedObjectPath;
 
 use crate::nm::{Mode, NMClient};
 
@@ -13,7 +13,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::FocusedBlock,
+    app::{AdapterView, FocusedBlock},
     config::Config,
     mode::{ap::AccessPoint, station::Station},
 };
@@ -31,11 +31,7 @@ pub struct Device {
 }
 
 impl Device {
-    pub async fn new(client: Arc<NMClient>) -> Result<Self> {
-        let device_path = client
-            .get_wifi_device()
-            .await
-            .context("No WiFi device found")?;
+    pub async fn new(client: Arc<NMClient>, device_path: OwnedObjectPath) -> Result<Self> {
         let device_path_str = device_path.as_str().to_string();
 
         let name = client.get_device_interface(&device_path_str).await?;
@@ -149,13 +145,19 @@ impl Device {
         Ok(())
     }
 
-    pub fn render(&mut self, frame: &mut Frame, focused_block: FocusedBlock, config: Arc<Config>) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame,
+        focused_block: FocusedBlock,
+        config: Arc<Config>,
+        view: &AdapterView,
+    ) {
         let (device_block, help_block) = {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
                     Constraint::Fill(1),
-                    Constraint::Length(5),
+                    Constraint::Length(AdapterView::BLOCK_HEIGHT),
                     Constraint::Length(1),
                 ])
                 .margin(1)
@@ -163,24 +165,23 @@ impl Device {
             (chunks[1], chunks[2])
         };
 
-        //
-        // Device
-        //
-        let row = Row::new(vec![Line::from(self.name.clone()).centered(), {
-            if self.is_powered {
-                Line::from("On").centered()
-            } else {
-                Line::from("Off").centered()
-            }
-        }]);
+        let is_powered = self.is_powered;
+        let rows = view.build_rows(
+            |adapter, marker| active_device_row(&adapter.name, is_powered, marker),
+            |adapter| inactive_device_row(&adapter.name),
+        );
+        let widths = [
+            Constraint::Length(16),
+            Constraint::Length(8),
+            Constraint::Length(6),
+        ];
 
-        let widths = [Constraint::Length(10), Constraint::Length(8)];
-
-        let device_table = Table::new(vec![row], widths)
+        let device_table = Table::new(rows, widths)
             .header({
                 Row::new(vec![
                     Line::from("Name").yellow().centered(),
                     Line::from("Powered").yellow().centered(),
+                    Line::from("Active").yellow().centered(),
                 ])
                 .style(Style::new().bold())
                 .bottom_margin(1)
@@ -198,28 +199,65 @@ impl Device {
             .flex(Flex::SpaceAround)
             .row_highlight_style(Style::default().bg(Color::DarkGray).fg(Color::White));
 
-        let mut device_state = TableState::default().with_selected(0);
+        let mut device_state =
+            TableState::default().with_selected(view.table_selection(focused_block));
         frame.render_stateful_widget(device_table, device_block, &mut device_state);
 
-        let help_message = match focused_block {
-            FocusedBlock::Device => Line::from(vec![
-                Span::from(config.device.infos.to_string()).bold(),
-                Span::from(" Infos"),
-                Span::from(" | "),
-                Span::from(config.device.toggle_power.to_string()).bold(),
-                Span::from(" Toggle Power"),
-                Span::from(" | "),
-                Span::from(config.device.doctor.to_string()).bold(),
-                Span::from(" Doctor"),
-            ]),
+        let help_message = Self::help_line(focused_block, &config, view.is_multi());
+        frame.render_widget(help_message.centered().blue(), help_block);
+    }
+
+    fn help_line<'a>(focused_block: FocusedBlock, config: &Config, multi: bool) -> Line<'a> {
+        match focused_block {
+            FocusedBlock::Device => {
+                let mut spans = vec![
+                    Span::from(config.device.infos.to_string()).bold(),
+                    Span::from(" Infos"),
+                    Span::from(" | "),
+                    Span::from(config.device.toggle_power.to_string()).bold(),
+                    Span::from(" Toggle Power"),
+                    Span::from(" | "),
+                    Span::from(config.device.doctor.to_string()).bold(),
+                    Span::from(" Doctor"),
+                ];
+                if multi {
+                    spans.extend(adapter_nav_spans());
+                }
+                Line::from(spans)
+            }
             FocusedBlock::AdapterInfos => {
                 Line::from(vec![Span::from("󱊷 ").bold(), Span::from(" Discard")])
             }
             _ => Line::from(""),
-        };
-
-        let help_message = help_message.centered().blue();
-
-        frame.render_widget(help_message, help_block);
+        }
     }
+}
+
+/// Help-line fragment shown when adapter navigation is active. Shared by the
+/// Device / Station / AP help rows so the keybinding hint stays in sync.
+pub fn adapter_nav_spans<'a>() -> Vec<Span<'a>> {
+    vec![
+        Span::from(" | "),
+        Span::from("j/k").bold(),
+        Span::from(" Move"),
+        Span::from(" | "),
+        Span::from("⏎").bold(),
+        Span::from(" Activate"),
+    ]
+}
+
+fn active_device_row<'a>(name: &str, is_powered: bool, marker: &str) -> Row<'a> {
+    Row::new(vec![
+        Line::from(name.to_string()).centered(),
+        Line::from(if is_powered { "On" } else { "Off" }).centered(),
+        Line::from(marker.to_string()).centered(),
+    ])
+}
+
+fn inactive_device_row<'a>(name: &str) -> Row<'a> {
+    Row::new(vec![
+        Line::from(name.to_string()).centered(),
+        Line::from("-").centered(),
+        Line::from("").centered(),
+    ])
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -154,6 +154,31 @@ async fn toggle_device_power(sender: UnboundedSender<Event>, device: &Device) ->
     Ok(())
 }
 
+/// Handles adapter list navigation (j/k/arrows) and activation (Enter/Space)
+/// when the Device block is focused. Returns `true` when the event was
+/// consumed so the caller short-circuits further processing.
+async fn handle_adapter_navigation(app: &mut App, key_event: KeyEvent) -> Result<bool> {
+    if app.focused_block != FocusedBlock::Device || app.adapter_count() <= 1 {
+        return Ok(false);
+    }
+
+    match key_event.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            app.move_adapter_selection(1);
+            Ok(true)
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            app.move_adapter_selection(-1);
+            Ok(true)
+        }
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            app.activate_selected_adapter().await?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
 pub async fn handle_key_events(
     key_event: KeyEvent,
     app: &mut App,
@@ -206,6 +231,14 @@ pub async fn handle_key_events(
         && c == config.device.doctor
     {
         start_doctor(app, sender).await;
+        return Ok(());
+    }
+
+    // Adapter navigation is active whenever the Device block has focus and
+    // more than one adapter exists — intercept before the mode/power branches
+    // so j/k/Enter don't reach the network list handlers. The doctor trigger
+    // above takes precedence because its key set ('?') doesn't overlap here.
+    if handle_adapter_navigation(app, key_event).await? {
         return Ok(());
     }
 

--- a/src/mode/ap.rs
+++ b/src/mode/ap.rs
@@ -15,13 +15,37 @@ use ratatui::{
 };
 
 use crate::{
-    app::FocusedBlock,
+    app::{AdapterView, FocusedBlock},
     config::Config,
-    device::Device,
+    device::{Device, adapter_nav_spans},
     event::Event,
     notification::{Notification, NotificationLevel},
 };
 use tui_input::Input;
+
+/// Row for the adapter currently hosting the AP. Carries Powered / Address
+/// from the live Device plus an optional active marker.
+fn active_ap_row<'a>(name: &str, device: &Device, marker: &str) -> Row<'a> {
+    Row::new(vec![
+        Line::from(name.to_string()).centered(),
+        Line::from("Access Point").centered(),
+        Line::from(if device.is_powered { "On" } else { "Off" }).centered(),
+        Line::from(device.address.clone()).centered(),
+        Line::from(marker.to_string()).centered(),
+    ])
+}
+
+/// Row for an adapter that is *not* the active AP. Address/Powered are
+/// unknown for adapters we haven't instantiated, so they dash out.
+fn inactive_ap_row<'a>(name: &str) -> Row<'a> {
+    Row::new(vec![
+        Line::from(name.to_string()).centered(),
+        Line::from("Access Point").centered(),
+        Line::from("-").centered(),
+        Line::from("-").centered(),
+        Line::from("").centered(),
+    ])
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum APFocusedSection {
@@ -356,69 +380,66 @@ impl AccessPoint {
         focused_block: FocusedBlock,
         device: &Device,
         config: Arc<Config>,
+        view: &AdapterView,
     ) {
         let (access_point_block, connected_devices_block, device_block, help_block) = {
+            let constraints: [Constraint; 4] = if !self.connected_devices.is_empty() {
+                [
+                    Constraint::Length(5),
+                    Constraint::Fill(1),
+                    Constraint::Length(AdapterView::BLOCK_HEIGHT),
+                    Constraint::Length(1),
+                ]
+            } else {
+                [
+                    Constraint::Fill(1),
+                    Constraint::Length(0),
+                    Constraint::Length(AdapterView::BLOCK_HEIGHT),
+                    Constraint::Length(1),
+                ]
+            };
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints(if !self.connected_devices.is_empty() {
-                    &[
-                        Constraint::Length(5),
-                        Constraint::Fill(1),
-                        Constraint::Length(5),
-                        Constraint::Length(1),
-                    ]
-                } else {
-                    &[
-                        Constraint::Fill(1),
-                        Constraint::Length(0),
-                        Constraint::Length(5),
-                        Constraint::Length(1),
-                    ]
-                })
+                .constraints(constraints)
                 .margin(1)
                 .split(frame.area());
             (chunks[0], chunks[1], chunks[2], chunks[3])
         };
 
-        // Device
-        let row = Row::new(vec![
-            Line::from(device.name.clone()).centered(),
-            Line::from("Access Point").centered(),
-            {
-                if device.is_powered {
-                    Line::from("On").centered()
-                } else {
-                    Line::from("Off").centered()
-                }
-            },
-            Line::from(device.address.clone()).centered(),
-        ]);
+        // Device — one row per adapter. Inactive rows dash out mode-specific
+        // columns; active row carries the real Powered/Address values.
+        let rows = view.build_rows(
+            |adapter, marker| active_ap_row(&adapter.name, device, marker),
+            |adapter| inactive_ap_row(&adapter.name),
+        );
 
         let widths = [
             Constraint::Length(15),
             Constraint::Length(12),
             Constraint::Length(7),
             Constraint::Length(17),
+            Constraint::Length(6),
         ];
 
-        let device_table = Table::new(vec![row], widths)
+        let device_table = Table::new(rows, widths)
             .header({
+                let labels = ["Name", "Mode", "Powered", "Address", "Active"];
                 if focused_block == FocusedBlock::Device {
-                    Row::new(vec![
-                        Line::from("Name").yellow().centered(),
-                        Line::from("Mode").yellow().centered(),
-                        Line::from("Powered").yellow().centered(),
-                        Line::from("Address").yellow().centered(),
-                    ])
+                    Row::new(
+                        labels
+                            .iter()
+                            .map(|l| Line::from(*l).yellow().centered())
+                            .collect::<Vec<_>>(),
+                    )
                     .style(Style::new().bold())
                     .bottom_margin(1)
                 } else {
-                    Row::new(vec![
-                        Line::from("Name").centered(),
-                        Line::from("Mode").centered(),
-                        Line::from("Powered").centered(),
-                        Line::from("Address").centered(),
-                    ])
+                    Row::new(
+                        labels
+                            .iter()
+                            .map(|l| Line::from(*l).centered())
+                            .collect::<Vec<_>>(),
+                    )
                     .bottom_margin(1)
                 }
             })
@@ -457,7 +478,8 @@ impl AccessPoint {
                 Style::default()
             });
 
-        let mut device_state = TableState::default().with_selected(0);
+        let mut device_state =
+            TableState::default().with_selected(view.table_selection(focused_block));
         frame.render_stateful_widget(device_table, device_block, &mut device_state);
 
         // Access Point
@@ -610,22 +632,28 @@ impl AccessPoint {
         }
 
         let help_message = match focused_block {
-            FocusedBlock::Device => Line::from(vec![
-                Span::from(config.device.infos.to_string()).bold(),
-                Span::from(" Infos"),
-                Span::from(" | "),
-                Span::from(config.device.toggle_power.to_string()).bold(),
-                Span::from(" Toggle Power"),
-                Span::from(" | "),
-                Span::from(config.device.doctor.to_string()).bold(),
-                Span::from(" Doctor"),
-                Span::from(" | "),
-                Span::from("ctrl+r").bold(),
-                Span::from(" Switch Mode"),
-                Span::from(" | "),
-                Span::from("⇄").bold(),
-                Span::from(" Nav"),
-            ]),
+            FocusedBlock::Device => {
+                let mut spans = vec![
+                    Span::from(config.device.infos.to_string()).bold(),
+                    Span::from(" Infos"),
+                    Span::from(" | "),
+                    Span::from(config.device.toggle_power.to_string()).bold(),
+                    Span::from(" Toggle Power"),
+                    Span::from(" | "),
+                    Span::from(config.device.doctor.to_string()).bold(),
+                    Span::from(" Doctor"),
+                    Span::from(" | "),
+                    Span::from("ctrl+r").bold(),
+                    Span::from(" Switch Mode"),
+                    Span::from(" | "),
+                    Span::from("⇄").bold(),
+                    Span::from(" Nav"),
+                ];
+                if view.is_multi() {
+                    spans.extend(adapter_nav_spans());
+                }
+                Line::from(spans)
+            }
             FocusedBlock::AdapterInfos | FocusedBlock::AccessPointInput => Line::from(vec![
                 Span::from("󱊷 ").bold(),
                 Span::from(" Discard"),

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -18,15 +18,31 @@ use ratatui::{
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-    app::FocusedBlock,
+    app::{AdapterView, FocusedBlock},
     config::Config,
-    device::Device,
+    device::{Device, adapter_nav_spans},
     event::Event,
     mode::station::{known_network::KnownNetwork, share::Share, speed_test::SpeedTest},
     notification::{Notification, NotificationLevel},
 };
 
 use network::Network;
+
+/// Row for an adapter that is *not* the active Station. Runtime columns are
+/// dashed out because state/scanning/frequency/security only exist on the
+/// active adapter; the name and mode are enough for the user to pick it.
+fn inactive_station_row<'a>(name: &str) -> Row<'a> {
+    Row::new(vec![
+        Line::from(name.to_string()).centered(),
+        Line::from("station").centered(),
+        Line::from("-").centered(),
+        Line::from("-").centered(),
+        Line::from("-").centered(),
+        Line::from("-").centered(),
+        Line::from("-").centered(),
+        Line::from("").centered(),
+    ])
+}
 
 /// Result of resolving the selected known networks table index,
 /// accounting for the ethernet row offset.
@@ -394,12 +410,41 @@ impl Station {
         ethernet_offset + self.known_networks.len() + unavail
     }
 
+    /// Row for the adapter currently active on this Station. Carries the full
+    /// set of runtime columns (state/scanning/frequency/security) plus an
+    /// optional active marker for the multi-adapter case.
+    fn active_device_row<'a>(&self, name: &str, device: &Device, marker: &str) -> Row<'a> {
+        let frequency = self
+            .diagnostic
+            .as_ref()
+            .and_then(|d| d.frequency)
+            .map(|freq| format!("{:.2} GHz", freq as f32 / 1000.))
+            .unwrap_or_else(|| "-".to_string());
+        let security = self
+            .diagnostic
+            .as_ref()
+            .and_then(|d| d.security.clone())
+            .unwrap_or_else(|| "-".to_string());
+
+        Row::new(vec![
+            Line::from(name.to_string()).centered(),
+            Line::from("station").centered(),
+            Line::from(if device.is_powered { "On" } else { "Off" }).centered(),
+            Line::from(self.state.to_string()).centered(),
+            Line::from(if self.is_scanning { "Yes" } else { "No" }).centered(),
+            Line::from(frequency).centered(),
+            Line::from(security).centered(),
+            Line::from(marker.to_string()).centered(),
+        ])
+    }
+
     pub fn render(
         &mut self,
         frame: &mut Frame,
         focused_block: FocusedBlock,
         device: &Device,
         config: Arc<Config>,
+        view: &AdapterView,
     ) {
         let (known_networks_block, new_networks_block, device_block, help_block) = {
             let chunks = Layout::default()
@@ -407,7 +452,7 @@ impl Station {
                 .constraints([
                     Constraint::Min(5),
                     Constraint::Min(5),
-                    Constraint::Length(5),
+                    Constraint::Length(AdapterView::BLOCK_HEIGHT),
                     Constraint::Length(2),
                 ])
                 .margin(1)
@@ -416,41 +461,14 @@ impl Station {
         };
 
         //
-        // Device
+        // Device — one row per adapter. Inactive rows carry only identity so
+        // the user can see and select them; station-specific columns are only
+        // populated for the active adapter.
         //
-        let row = Row::new(vec![
-            Line::from(device.name.clone()).centered(),
-            Line::from("station").centered(),
-            {
-                if device.is_powered {
-                    Line::from("On").centered()
-                } else {
-                    Line::from("Off").centered()
-                }
-            },
-            Line::from(self.state.to_string()).centered(),
-            Line::from(if self.is_scanning { "Yes" } else { "No" }).centered(),
-            Line::from({
-                if let Some(diagnostic) = &self.diagnostic {
-                    if let Some(freq) = diagnostic.frequency {
-                        format!("{:.2} GHz", freq as f32 / 1000.)
-                    } else {
-                        "-".to_string()
-                    }
-                } else {
-                    "-".to_string()
-                }
-            })
-            .centered(),
-            Line::from({
-                if let Some(diagnostic) = &self.diagnostic {
-                    diagnostic.security.clone().unwrap_or("-".to_string())
-                } else {
-                    "-".to_string()
-                }
-            })
-            .centered(),
-        ]);
+        let rows = view.build_rows(
+            |adapter, marker| self.active_device_row(&adapter.name, device, marker),
+            |adapter| inactive_station_row(&adapter.name),
+        );
 
         let widths = [
             Constraint::Length(10),
@@ -460,32 +478,37 @@ impl Station {
             Constraint::Length(10),
             Constraint::Length(10),
             Constraint::Length(15),
+            Constraint::Length(6),
         ];
 
-        let device_table = Table::new(vec![row], widths)
+        let device_table = Table::new(rows, widths)
             .header({
+                let labels = [
+                    "Name",
+                    "Mode",
+                    "Powered",
+                    "State",
+                    "Scanning",
+                    "Frequency",
+                    "Security",
+                    "Active",
+                ];
                 if focused_block == FocusedBlock::Device {
-                    Row::new(vec![
-                        Line::from("Name").yellow().centered(),
-                        Line::from("Mode").yellow().centered(),
-                        Line::from("Powered").yellow().centered(),
-                        Line::from("State").yellow().centered(),
-                        Line::from("Scanning").yellow().centered(),
-                        Line::from("Frequency").yellow().centered(),
-                        Line::from("Security").yellow().centered(),
-                    ])
+                    Row::new(
+                        labels
+                            .iter()
+                            .map(|l| Line::from(*l).yellow().centered())
+                            .collect::<Vec<_>>(),
+                    )
                     .style(Style::new().bold())
                     .bottom_margin(1)
                 } else {
-                    Row::new(vec![
-                        Line::from("Name").centered(),
-                        Line::from("Mode").centered(),
-                        Line::from("Powered").centered(),
-                        Line::from("State").centered(),
-                        Line::from("Scanning").centered(),
-                        Line::from("Frequency").centered(),
-                        Line::from("Security").centered(),
-                    ])
+                    Row::new(
+                        labels
+                            .iter()
+                            .map(|l| Line::from(*l).centered())
+                            .collect::<Vec<_>>(),
+                    )
                     .bottom_margin(1)
                 }
             })
@@ -524,7 +547,8 @@ impl Station {
                 Style::default()
             });
 
-        let mut device_state = TableState::default().with_selected(0);
+        let mut device_state =
+            TableState::default().with_selected(view.table_selection(focused_block));
         frame.render_stateful_widget(device_table, device_block, &mut device_state);
 
         //
@@ -786,25 +810,31 @@ impl Station {
         );
 
         let help_message = match focused_block {
-            FocusedBlock::Device => vec![Line::from(vec![
-                Span::from(config.station.start_scanning.to_string()).bold(),
-                Span::from(" Scan"),
-                Span::from(" | "),
-                Span::from(config.device.infos.to_string()).bold(),
-                Span::from(" Infos"),
-                Span::from(" | "),
-                Span::from(config.device.toggle_power.to_string()).bold(),
-                Span::from(" Toggle Power"),
-                Span::from(" | "),
-                Span::from(config.device.doctor.to_string()).bold(),
-                Span::from(" Doctor"),
-                Span::from(" | "),
-                Span::from("ctrl+r").bold(),
-                Span::from(" Switch Mode"),
-                Span::from(" | "),
-                Span::from("⇄").bold(),
-                Span::from(" Nav"),
-            ])],
+            FocusedBlock::Device => {
+                let mut spans = vec![
+                    Span::from(config.station.start_scanning.to_string()).bold(),
+                    Span::from(" Scan"),
+                    Span::from(" | "),
+                    Span::from(config.device.infos.to_string()).bold(),
+                    Span::from(" Infos"),
+                    Span::from(" | "),
+                    Span::from(config.device.toggle_power.to_string()).bold(),
+                    Span::from(" Toggle Power"),
+                    Span::from(" | "),
+                    Span::from(config.device.doctor.to_string()).bold(),
+                    Span::from(" Doctor"),
+                    Span::from(" | "),
+                    Span::from("ctrl+r").bold(),
+                    Span::from(" Switch Mode"),
+                    Span::from(" | "),
+                    Span::from("⇄").bold(),
+                    Span::from(" Nav"),
+                ];
+                if view.is_multi() {
+                    spans.extend(adapter_nav_spans());
+                }
+                vec![Line::from(spans)]
+            }
             FocusedBlock::KnownNetworks => {
                 if frame.area().width <= 130 {
                     vec![

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,26 +3,38 @@ use std::sync::atomic::Ordering;
 use crate::nm::Mode;
 use ratatui::Frame;
 
-use crate::app::{App, FocusedBlock};
+use crate::app::{AdapterView, App, FocusedBlock};
 
 pub fn render(app: &mut App, frame: &mut Frame) {
     if app.reset.enable {
         app.reset.render(frame);
     } else {
+        let view = AdapterView {
+            adapters: &app.adapters,
+            active_index: app.active_index,
+            selection_index: app.adapter_selection_index,
+        };
+
         if !app.device.is_powered {
             app.device
-                .render(frame, app.focused_block, app.config.clone())
+                .render(frame, app.focused_block, app.config.clone(), &view)
         } else {
             let device = app.device.clone();
             match app.device.mode {
                 Mode::Station => {
                     if let Some(station) = &mut app.device.station {
-                        station.render(frame, app.focused_block, &device, app.config.clone());
+                        station.render(
+                            frame,
+                            app.focused_block,
+                            &device,
+                            app.config.clone(),
+                            &view,
+                        );
                     }
                 }
                 Mode::Ap => {
                     if let Some(ap) = &mut app.device.ap {
-                        ap.render(frame, app.focused_block, &device, app.config.clone());
+                        ap.render(frame, app.focused_block, &device, app.config.clone(), &view);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Closes #34. Adds multi-adapter support so users with multiple WiFi devices can cycle between them from the Device block.

- `App` now tracks the full list of WiFi device paths plus an `active_index`, while `device: Device` remains the current active adapter (split-borrow friendly — no churn in handler/ui)
- `Device::new` takes a `device_path` parameter explicitly instead of auto-picking the first
- New `app.switch_adapter(delta)` rebuilds `Device` + `Adapter` on the chosen path, preserves the user's current `Mode` across the switch, and resets focus to a sensible block
- Device block renders `wlan0 [1/2]` and appends the switch-adapter hint to the help line when more than one adapter is present
- Hotplug handled in `tick()`: re-fetches the device list, keeps `active_index` pointing at the same device if it still exists, otherwise falls back to the first available device (rebuilding `Adapter` too); errors if none remain
- Default keybinding is `m` in Device focus (configurable via `device.switch_adapter`), only active when there are 2+ adapters

## UX

- Single adapter: zero visible change
- Multiple adapters: Device block shows `[i/n]` indicator, pressing `m` cycles forward

## Test plan

- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (11 tests)
- [x] `cargo build --release` succeeds
- [ ] Manual verification on a machine with 2+ WiFi adapters (scan, connect, switch, scan again)
- [x] Manual verification on single-adapter machine shows no UI change
- [ ] Hotplug: unplug the active USB adapter and confirm graceful fallback to remaining adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-adapter management with a compact adapter list and visible "active" indicator
  * Keyboard navigation for adapter selection (arrow keys / j,k) and activation via Enter/Space
  * Switching adapters preserves the device's prior mode
  * Adapter list refreshes at runtime and selection/active state is reconciled across adapter reorderings or removals
  * Initialization and reset now ensure an adapter is selected before showing device UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->