### PR TITLE
chore: consolidate Renovate into a single grouped PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,30 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommits",
+    "schedule:weekly"
+  ],
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 0,
+  "rebaseWhen": "conflicted",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": "all major dependencies",
+      "groupSlug": "all-major",
+      "dependencyDashboardApproval": true,
+      "semanticCommitType": "chore"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

The current Renovate config (default `config:recommended`) opens one PR per dependency — it already created 19 PRs (#37–#55) and is flooding the board.

This PR replaces the config so Renovate:

- Groups **all non-major updates** into a single PR
- Gates **major updates** behind Dependency Dashboard approval (tick a box on #39 to open them), also grouped into one PR
- Runs on a **weekly schedule** (Monday mornings), with `prConcurrentLimit: 2` as a safety cap
- Keeps `flake.lock` / `Cargo.lock` fresh via weekly `lockFileMaintenance`
- Uses semantic commit types (`chore:`)

## What happens after merge

Renovate will re-evaluate on its next run and supersede the 19 individual PRs with its grouped ones. Any you want to merge manually first (e.g. a specific crate) should be merged before this lands; everything else can be closed en masse.

## Trade-off

One grouped PR means you can't easily cherry-pick which deps to bump — the whole group lands or nothing does. The alternative (individual PRs) caused the flood. Grouping is the right default; specific crates can be carved out later via `packageRules` if needed.

## Test plan

- [x] Merge this PR
- [ ] Close the existing Renovate PRs (#37–#55) — or let Renovate auto-close them on next run
- [ ] Wait for Monday's run (or force-trigger via the Dependency Dashboard #39) and confirm a single grouped PR appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management automation with improved scheduling and update grouping for better stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->