### PR TITLE
feat: add `wlctl doctor` — one-shot network diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,6 +2103,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-channel",
+ "async-trait",
  "chrono",
  "clap",
  "crossterm 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ libc = "0.2"
 hex = "0.4.3"
 tui-qrcode = "0.1.3"
 qrcode = "0.14.1"
+async-trait = "0.1"
 
 [profile.release]
 strip = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,9 @@ pub fn cli() -> Command {
     Command::new("wlctl")
         .about("TUI for managing WiFi using NetworkManager")
         .version(crate_version!())
+        // Root-level args (--mode) are for launching the TUI; they do not apply
+        // when a subcommand like `doctor` is used.
+        .args_conflicts_with_subcommands(true)
         .arg(
             arg!(--mode <mode>)
                 .short('m')

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,4 +11,8 @@ pub fn cli() -> Command {
                 .help("Device mode")
                 .value_parser(["station", "ap"]),
         )
+        .subcommand(
+            Command::new("doctor")
+                .about("Diagnose why your WiFi isn't working (rfkill, driver, DHCP, DNS, ...)"),
+        )
 }

--- a/src/doctor/check.rs
+++ b/src/doctor/check.rs
@@ -1,0 +1,88 @@
+use async_trait::async_trait;
+
+use super::context::DoctorContext;
+
+/// The verdict of a single diagnostic step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Ok,
+    Warn,
+    Fail,
+    Skip,
+}
+
+/// Result of one diagnostic check.
+#[derive(Debug, Clone)]
+pub struct Outcome {
+    pub status: Status,
+    pub summary: String,
+    pub verdict: Option<String>,
+}
+
+impl Outcome {
+    pub fn ok(summary: impl Into<String>) -> Self {
+        Self {
+            status: Status::Ok,
+            summary: summary.into(),
+            verdict: None,
+        }
+    }
+
+    pub fn warn(summary: impl Into<String>) -> Self {
+        Self {
+            status: Status::Warn,
+            summary: summary.into(),
+            verdict: None,
+        }
+    }
+
+    pub fn fail(summary: impl Into<String>, verdict: impl Into<String>) -> Self {
+        Self {
+            status: Status::Fail,
+            summary: summary.into(),
+            verdict: Some(verdict.into()),
+        }
+    }
+
+    pub fn skip(summary: impl Into<String>) -> Self {
+        Self {
+            status: Status::Skip,
+            summary: summary.into(),
+            verdict: None,
+        }
+    }
+}
+
+/// A single diagnostic check. Each implementation owns exactly one concern —
+/// rfkill, driver presence, DHCP lease, DNS resolution, etc.
+#[async_trait]
+pub trait DiagnosticCheck: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn run(&self, ctx: &DoctorContext) -> Outcome;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ok_has_no_verdict() {
+        let o = Outcome::ok("fine");
+        assert_eq!(o.status, Status::Ok);
+        assert_eq!(o.summary, "fine");
+        assert!(o.verdict.is_none());
+    }
+
+    #[test]
+    fn fail_carries_verdict() {
+        let o = Outcome::fail("broken", "do the thing");
+        assert_eq!(o.status, Status::Fail);
+        assert_eq!(o.verdict.as_deref(), Some("do the thing"));
+    }
+
+    #[test]
+    fn warn_and_skip_have_no_verdict() {
+        assert!(Outcome::warn("warn").verdict.is_none());
+        assert!(Outcome::skip("skip").verdict.is_none());
+    }
+}

--- a/src/doctor/checks/association.rs
+++ b/src/doctor/checks/association.rs
@@ -30,7 +30,7 @@ impl DiagnosticCheck for AssociationCheck {
                 };
                 Outcome::ok(format!("{} ({}% signal)", ssid, info.strength))
             }
-            Err(_) => Outcome::ok("associated (AP details unreadable)"),
+            Err(e) => Outcome::warn(format!("associated but AP details unreadable: {}", e)),
         }
     }
 }

--- a/src/doctor/checks/association.rs
+++ b/src/doctor/checks/association.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+
+/// Looks up the currently-associated access point and reports its SSID.
+pub struct AssociationCheck;
+
+#[async_trait]
+impl DiagnosticCheck for AssociationCheck {
+    fn name(&self) -> &'static str {
+        "association"
+    }
+
+    async fn run(&self, ctx: &DoctorContext) -> Outcome {
+        let ap_path = match ctx.nm.get_active_access_point(&ctx.device_path).await {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                return Outcome::warn("not associated with any AP");
+            }
+            Err(e) => return Outcome::skip(format!("could not read active AP: {}", e)),
+        };
+
+        match ctx.nm.get_access_point_info(ap_path.as_str()).await {
+            Ok(info) => {
+                let ssid = if info.ssid.is_empty() {
+                    "<hidden>"
+                } else {
+                    info.ssid.as_str()
+                };
+                Outcome::ok(format!("{} ({}% signal)", ssid, info.strength))
+            }
+            Err(_) => Outcome::ok("associated (AP details unreadable)"),
+        }
+    }
+}

--- a/src/doctor/checks/device_state.rs
+++ b/src/doctor/checks/device_state.rs
@@ -1,0 +1,40 @@
+use async_trait::async_trait;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+use crate::nm::DeviceState;
+
+/// Reports the NetworkManager device state (DISCONNECTED, CONNECTING, ACTIVATED...).
+pub struct DeviceStateCheck;
+
+#[async_trait]
+impl DiagnosticCheck for DeviceStateCheck {
+    fn name(&self) -> &'static str {
+        "interface"
+    }
+
+    async fn run(&self, ctx: &DoctorContext) -> Outcome {
+        match ctx.nm.get_device_state(&ctx.device_path).await {
+            Ok(state) => match state {
+                DeviceState::Activated => Outcome::ok(format!("{} is ACTIVATED", ctx.interface)),
+                DeviceState::Config | DeviceState::IpConfig | DeviceState::IpCheck => {
+                    Outcome::warn(format!("{} still configuring ({:?})", ctx.interface, state))
+                }
+                DeviceState::Disconnected | DeviceState::Deactivating => Outcome::warn(format!(
+                    "{} is {:?} — no active connection",
+                    ctx.interface, state
+                )),
+                DeviceState::Unavailable => Outcome::fail(
+                    format!("{} is UNAVAILABLE", ctx.interface),
+                    "NetworkManager cannot manage this device. Check rfkill and driver state above.",
+                ),
+                DeviceState::Failed => Outcome::fail(
+                    format!("{} is FAILED", ctx.interface),
+                    "Last connection attempt failed. Check `journalctl -u NetworkManager -n 50`.",
+                ),
+                _ => Outcome::warn(format!("{} state: {:?}", ctx.interface, state)),
+            },
+            Err(e) => Outcome::skip(format!("could not read device state: {}", e)),
+        }
+    }
+}

--- a/src/doctor/checks/dns.rs
+++ b/src/doctor/checks/dns.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::net::lookup_host;
+use tokio::time::timeout;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+
+const PROBE_HOST: &str = "one.one.one.one:80";
+const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Resolves a well-known host to confirm DNS is working.
+pub struct DnsCheck;
+
+#[async_trait]
+impl DiagnosticCheck for DnsCheck {
+    fn name(&self) -> &'static str {
+        "dns"
+    }
+
+    async fn run(&self, _ctx: &DoctorContext) -> Outcome {
+        match timeout(DNS_TIMEOUT, lookup_host(PROBE_HOST)).await {
+            Ok(Ok(mut addrs)) => match addrs.next() {
+                Some(addr) => Outcome::ok(format!("resolves ({})", addr.ip())),
+                None => Outcome::fail(
+                    "DNS returned no records",
+                    "Resolver reachable but empty response. Check /etc/resolv.conf.",
+                ),
+            },
+            Ok(Err(e)) => Outcome::fail(
+                format!("DNS lookup failed: {}", e),
+                "Check your DNS servers (nmcli -g IP4.DNS device show) or try overriding with 1.1.1.1.",
+            ),
+            Err(_) => Outcome::fail(
+                format!("DNS lookup timed out after {}s", DNS_TIMEOUT.as_secs()),
+                "DNS server is unreachable. Check /etc/resolv.conf or the router's DNS.",
+            ),
+        }
+    }
+}

--- a/src/doctor/checks/driver.rs
+++ b/src/doctor/checks/driver.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+use tokio::fs;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+
+/// Reads /sys/class/net/<iface>/device/driver to confirm a kernel driver is
+/// bound to the wireless interface.
+pub struct DriverCheck;
+
+#[async_trait]
+impl DiagnosticCheck for DriverCheck {
+    fn name(&self) -> &'static str {
+        "driver"
+    }
+
+    async fn run(&self, ctx: &DoctorContext) -> Outcome {
+        let link = format!("/sys/class/net/{}/device/driver", ctx.interface);
+
+        match fs::read_link(&link).await {
+            Ok(target) => {
+                let name = target
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "unknown".into());
+                Outcome::ok(format!("{} loaded", name))
+            }
+            Err(_) => Outcome::fail(
+                "no driver bound",
+                format!(
+                    "No kernel driver for {}. Check `dmesg | grep -i {}` for firmware errors.",
+                    ctx.interface, ctx.interface
+                ),
+            ),
+        }
+    }
+}

--- a/src/doctor/checks/driver.rs
+++ b/src/doctor/checks/driver.rs
@@ -1,3 +1,5 @@
+use std::io::ErrorKind;
+
 use async_trait::async_trait;
 use tokio::fs;
 
@@ -25,13 +27,14 @@ impl DiagnosticCheck for DriverCheck {
                     .unwrap_or_else(|| "unknown".into());
                 Outcome::ok(format!("{} loaded", name))
             }
-            Err(_) => Outcome::fail(
+            Err(e) if e.kind() == ErrorKind::NotFound => Outcome::fail(
                 "no driver bound",
                 format!(
                     "No kernel driver for {}. Check `dmesg | grep -i {}` for firmware errors.",
                     ctx.interface, ctx.interface
                 ),
             ),
+            Err(e) => Outcome::skip(format!("could not read driver link: {}", e)),
         }
     }
 }

--- a/src/doctor/checks/gateway.rs
+++ b/src/doctor/checks/gateway.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -21,21 +22,28 @@ impl DiagnosticCheck for GatewayCheck {
     async fn run(&self, ctx: &DoctorContext) -> Outcome {
         let gateway = match ctx.nm.get_ip4_info(&ctx.device_path).await {
             Ok(Some(info)) => info.gateway,
-            _ => None,
+            Ok(None) => None,
+            Err(e) => return Outcome::skip(format!("could not read IP config: {}", e)),
         };
 
         let Some(gw) = gateway else {
             return Outcome::warn("no default gateway configured");
         };
 
-        // Port 80 picked arbitrarily; the RST from a closed port still proves
+        // Port 80 picked arbitrarily; a RST from a closed port still proves
         // the host is up. ICMP would need raw sockets / CAP_NET_RAW.
         let addr = format!("{}:80", gw);
         match timeout(GATEWAY_TIMEOUT, TcpStream::connect(&addr)).await {
             Ok(Ok(_)) => Outcome::ok(format!("{} reachable", gw)),
-            Ok(Err(_)) => Outcome::ok(format!("{} reachable (refused port 80)", gw)),
+            Ok(Err(e)) if e.kind() == ErrorKind::ConnectionRefused => {
+                Outcome::ok(format!("{} reachable (refused port 80)", gw))
+            }
+            Ok(Err(e)) => Outcome::fail(
+                format!("{} unreachable ({})", gw, e),
+                "Router-side issue. Try power-cycling the AP or moving closer.",
+            ),
             Err(_) => Outcome::fail(
-                format!("{} unreachable", gw),
+                format!("{} unreachable (timeout)", gw),
                 "Router-side issue. Try power-cycling the AP or moving closer.",
             ),
         }

--- a/src/doctor/checks/gateway.rs
+++ b/src/doctor/checks/gateway.rs
@@ -1,0 +1,43 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+
+const GATEWAY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Probes the default gateway with a short TCP SYN to confirm L3 reachability.
+pub struct GatewayCheck;
+
+#[async_trait]
+impl DiagnosticCheck for GatewayCheck {
+    fn name(&self) -> &'static str {
+        "gateway"
+    }
+
+    async fn run(&self, ctx: &DoctorContext) -> Outcome {
+        let gateway = match ctx.nm.get_ip4_info(&ctx.device_path).await {
+            Ok(Some(info)) => info.gateway,
+            _ => None,
+        };
+
+        let Some(gw) = gateway else {
+            return Outcome::warn("no default gateway configured");
+        };
+
+        // Port 80 picked arbitrarily; the RST from a closed port still proves
+        // the host is up. ICMP would need raw sockets / CAP_NET_RAW.
+        let addr = format!("{}:80", gw);
+        match timeout(GATEWAY_TIMEOUT, TcpStream::connect(&addr)).await {
+            Ok(Ok(_)) => Outcome::ok(format!("{} reachable", gw)),
+            Ok(Err(_)) => Outcome::ok(format!("{} reachable (refused port 80)", gw)),
+            Err(_) => Outcome::fail(
+                format!("{} unreachable", gw),
+                "Router-side issue. Try power-cycling the AP or moving closer.",
+            ),
+        }
+    }
+}

--- a/src/doctor/checks/internet.rs
+++ b/src/doctor/checks/internet.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+
+const INTERNET_HOSTS: &[&str] = &["1.1.1.1:443", "8.8.8.8:443"];
+const INTERNET_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// TCP-connects to well-known public endpoints to confirm end-to-end reachability.
+pub struct InternetCheck;
+
+#[async_trait]
+impl DiagnosticCheck for InternetCheck {
+    fn name(&self) -> &'static str {
+        "internet"
+    }
+
+    async fn run(&self, _ctx: &DoctorContext) -> Outcome {
+        for host in INTERNET_HOSTS {
+            if let Ok(Ok(_)) = timeout(INTERNET_TIMEOUT, TcpStream::connect(host)).await {
+                return Outcome::ok(format!("reachable via {}", host));
+            }
+        }
+
+        Outcome::fail(
+            "no public endpoint reachable",
+            "Internet is unreachable. Possible causes: captive portal, ISP outage, firewall.",
+        )
+    }
+}

--- a/src/doctor/checks/ip.rs
+++ b/src/doctor/checks/ip.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+
+/// Reports the active IPv4 address acquired via DHCP or static config.
+pub struct IpAddressCheck;
+
+#[async_trait]
+impl DiagnosticCheck for IpAddressCheck {
+    fn name(&self) -> &'static str {
+        "ip address"
+    }
+
+    async fn run(&self, ctx: &DoctorContext) -> Outcome {
+        match ctx.nm.get_ip4_info(&ctx.device_path).await {
+            Ok(Some(info)) if !info.addresses.is_empty() => {
+                let (addr, prefix) = &info.addresses[0];
+                Outcome::ok(format!("{}/{}", addr, prefix))
+            }
+            Ok(_) => Outcome::fail(
+                "no IPv4 address",
+                "DHCP did not assign an address. Try reconnecting, or check the router's DHCP pool.",
+            ),
+            Err(e) => Outcome::skip(format!("could not read IP config: {}", e)),
+        }
+    }
+}

--- a/src/doctor/checks/mod.rs
+++ b/src/doctor/checks/mod.rs
@@ -1,0 +1,19 @@
+mod association;
+mod device_state;
+mod dns;
+mod driver;
+mod gateway;
+mod internet;
+mod ip;
+mod portal;
+mod rfkill;
+
+pub use association::AssociationCheck;
+pub use device_state::DeviceStateCheck;
+pub use dns::DnsCheck;
+pub use driver::DriverCheck;
+pub use gateway::GatewayCheck;
+pub use internet::InternetCheck;
+pub use ip::IpAddressCheck;
+pub use portal::PortalCheck;
+pub use rfkill::RfkillCheck;

--- a/src/doctor/checks/portal.rs
+++ b/src/doctor/checks/portal.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+use crate::nm::Connectivity;
+
+/// Asks NetworkManager to re-run its connectivity probe and reports the result.
+pub struct PortalCheck;
+
+#[async_trait]
+impl DiagnosticCheck for PortalCheck {
+    fn name(&self) -> &'static str {
+        "connectivity"
+    }
+
+    async fn run(&self, ctx: &DoctorContext) -> Outcome {
+        match ctx.nm.check_connectivity().await {
+            Ok(Connectivity::Full) => Outcome::ok("full internet access"),
+            Ok(Connectivity::Portal) => Outcome::fail(
+                "captive portal detected",
+                "Open a browser and complete the login. (See issue #61 for auto-login.)",
+            ),
+            Ok(Connectivity::Limited) => Outcome::warn("limited — network reachable, no internet"),
+            Ok(Connectivity::None) => Outcome::warn("no connectivity"),
+            Ok(Connectivity::Unknown) => Outcome::skip("connectivity state unknown"),
+            Err(e) => Outcome::skip(format!("could not check connectivity: {}", e)),
+        }
+    }
+}

--- a/src/doctor/checks/rfkill.rs
+++ b/src/doctor/checks/rfkill.rs
@@ -19,6 +19,8 @@ impl DiagnosticCheck for RfkillCheck {
             Err(_) => return Outcome::skip("rfkill sysfs not available"),
         };
 
+        let mut saw_wlan = false;
+
         while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
 
@@ -28,23 +30,24 @@ impl DiagnosticCheck for RfkillCheck {
             if kind.trim() != "wlan" {
                 continue;
             }
+            saw_wlan = true;
 
-            let soft = read_flag(&path, "soft").await;
-            let hard = read_flag(&path, "hard").await;
-
-            if hard {
+            if read_flag(&path, "hard").await {
                 return Outcome::fail(
                     "wireless hard-blocked",
                     "Toggle the hardware WiFi switch (laptop kill switch or keyboard function key).",
                 );
             }
-            if soft {
+            if read_flag(&path, "soft").await {
                 return Outcome::fail("wireless soft-blocked", "Run: rfkill unblock wlan");
             }
-            return Outcome::ok("not blocked");
         }
 
-        Outcome::skip("no wlan rfkill entry found")
+        if saw_wlan {
+            Outcome::ok("not blocked")
+        } else {
+            Outcome::skip("no wlan rfkill entry found")
+        }
     }
 }
 

--- a/src/doctor/checks/rfkill.rs
+++ b/src/doctor/checks/rfkill.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use tokio::fs;
+
+use crate::doctor::check::{DiagnosticCheck, Outcome};
+use crate::doctor::context::DoctorContext;
+
+/// Reads /sys/class/rfkill to detect soft- or hard-blocked wireless radios.
+pub struct RfkillCheck;
+
+#[async_trait]
+impl DiagnosticCheck for RfkillCheck {
+    fn name(&self) -> &'static str {
+        "rfkill"
+    }
+
+    async fn run(&self, _ctx: &DoctorContext) -> Outcome {
+        let mut entries = match fs::read_dir("/sys/class/rfkill").await {
+            Ok(d) => d,
+            Err(_) => return Outcome::skip("rfkill sysfs not available"),
+        };
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+
+            let kind = fs::read_to_string(path.join("type"))
+                .await
+                .unwrap_or_default();
+            if kind.trim() != "wlan" {
+                continue;
+            }
+
+            let soft = read_flag(&path, "soft").await;
+            let hard = read_flag(&path, "hard").await;
+
+            if hard {
+                return Outcome::fail(
+                    "wireless hard-blocked",
+                    "Toggle the hardware WiFi switch (laptop kill switch or keyboard function key).",
+                );
+            }
+            if soft {
+                return Outcome::fail("wireless soft-blocked", "Run: rfkill unblock wlan");
+            }
+            return Outcome::ok("not blocked");
+        }
+
+        Outcome::skip("no wlan rfkill entry found")
+    }
+}
+
+async fn read_flag(dir: &std::path::Path, name: &str) -> bool {
+    fs::read_to_string(dir.join(name))
+        .await
+        .map(|s| s.trim() == "1")
+        .unwrap_or(false)
+}

--- a/src/doctor/context.rs
+++ b/src/doctor/context.rs
@@ -1,0 +1,11 @@
+use std::sync::Arc;
+
+use crate::nm::NMClient;
+
+/// Shared state passed to every diagnostic check. Checks are read-only — they
+/// must not mutate the NM state while running.
+pub struct DoctorContext {
+    pub nm: Arc<NMClient>,
+    pub device_path: String,
+    pub interface: String,
+}

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1,0 +1,84 @@
+//! Network diagnostic runner — walks the stack (rfkill → driver → interface →
+//! association → DHCP → DNS → gateway → internet → captive portal) and prints
+//! an interpreted verdict instead of raw logs.
+
+mod check;
+mod checks;
+mod context;
+mod report;
+
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+
+use crate::nm::NMClient;
+
+use check::{DiagnosticCheck, Outcome};
+use checks::{
+    AssociationCheck, DeviceStateCheck, DnsCheck, DriverCheck, GatewayCheck, InternetCheck,
+    IpAddressCheck, PortalCheck, RfkillCheck,
+};
+use context::DoctorContext;
+use report::Report;
+
+/// Composes the default set of diagnostic checks in stack order.
+pub struct Doctor {
+    checks: Vec<Box<dyn DiagnosticCheck>>,
+}
+
+impl Default for Doctor {
+    fn default() -> Self {
+        Self {
+            checks: vec![
+                Box::new(RfkillCheck),
+                Box::new(DriverCheck),
+                Box::new(DeviceStateCheck),
+                Box::new(AssociationCheck),
+                Box::new(IpAddressCheck),
+                Box::new(DnsCheck),
+                Box::new(GatewayCheck),
+                Box::new(InternetCheck),
+                Box::new(PortalCheck),
+            ],
+        }
+    }
+}
+
+impl Doctor {
+    /// Runs every check sequentially and returns an ordered list of results.
+    pub async fn run(&self, ctx: &DoctorContext) -> Vec<(&'static str, Outcome)> {
+        let mut results = Vec::with_capacity(self.checks.len());
+        for check in &self.checks {
+            let outcome = check.run(ctx).await;
+            results.push((check.name(), outcome));
+        }
+        results
+    }
+}
+
+/// Entry point invoked by the CLI. Builds a context for the first WiFi device
+/// and prints a formatted report to stdout.
+pub async fn run() -> Result<()> {
+    let nm = Arc::new(
+        NMClient::new()
+            .await
+            .context("Could not reach NetworkManager over D-Bus")?,
+    );
+
+    let device_path = nm.get_wifi_device().await.context("No WiFi device found")?;
+    let device_path_str = device_path.as_str().to_string();
+    let interface = nm.get_device_interface(&device_path_str).await?;
+
+    let ctx = DoctorContext {
+        nm,
+        device_path: device_path_str,
+        interface,
+    };
+
+    let doctor = Doctor::default();
+    let results = doctor.run(&ctx).await;
+
+    Report { entries: &results }.print();
+
+    Ok(())
+}

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -67,7 +67,10 @@ pub async fn run() -> Result<()> {
 
     let device_path = nm.get_wifi_device().await.context("No WiFi device found")?;
     let device_path_str = device_path.as_str().to_string();
-    let interface = nm.get_device_interface(&device_path_str).await?;
+    let interface = nm
+        .get_device_interface(&device_path_str)
+        .await
+        .context("Could not read interface name for WiFi device")?;
 
     let ctx = DoctorContext {
         nm,

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -1,0 +1,40 @@
+use super::check::{Outcome, Status};
+
+pub struct Report<'a> {
+    pub entries: &'a [(&'static str, Outcome)],
+}
+
+impl Report<'_> {
+    pub fn print(&self) {
+        for (name, outcome) in self.entries {
+            println!(
+                "{} {:<12} {}",
+                symbol(outcome.status),
+                name,
+                outcome.summary
+            );
+        }
+
+        let verdicts: Vec<&str> = self
+            .entries
+            .iter()
+            .filter_map(|(_, o)| o.verdict.as_deref())
+            .collect();
+
+        if !verdicts.is_empty() {
+            println!();
+            for v in verdicts {
+                println!("-> {}", v);
+            }
+        }
+    }
+}
+
+fn symbol(status: Status) -> &'static str {
+    match status {
+        Status::Ok => "[ok]  ",
+        Status::Warn => "[warn]",
+        Status::Fail => "[fail]",
+        Status::Skip => "[skip]",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod agent;
 
 pub mod nm;
 
+pub mod doctor;
+
 pub fn nm_network_name(name: &str) -> String {
     // NetworkManager handles SSID encoding internally, so we just return as-is
     name.to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use wlctl::{
     app::App,
     cli,
     config::Config,
+    doctor,
     event::{Event, EventHandler},
     handler::{handle_key_events, toggle_connect},
     nm::Mode,
@@ -24,6 +25,10 @@ async fn main() -> Result<()> {
         .init();
 
     let args = cli::cli().get_matches();
+
+    if let Some(("doctor", _)) = args.subcommand() {
+        return doctor::run().await;
+    }
 
     rfkill::check()?;
 

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -165,15 +165,11 @@ impl NMClient {
         )
         .await?;
 
-        let address_data: Vec<HashMap<String, OwnedValue>> = ip4_proxy
-            .get_property("AddressData")
-            .await
-            .unwrap_or_default();
-        let gateway: String = ip4_proxy.get_property("Gateway").await.unwrap_or_default();
-        let nameservers: Vec<HashMap<String, OwnedValue>> = ip4_proxy
-            .get_property("NameserverData")
-            .await
-            .unwrap_or_default();
+        let address_data: Vec<HashMap<String, OwnedValue>> =
+            ip4_proxy.get_property("AddressData").await?;
+        let gateway: String = ip4_proxy.get_property("Gateway").await?;
+        let nameservers: Vec<HashMap<String, OwnedValue>> =
+            ip4_proxy.get_property("NameserverData").await?;
 
         let addresses = address_data
             .into_iter()

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -141,6 +141,88 @@ impl NMClient {
         Ok(())
     }
 
+    /// Get the IPv4 configuration in use on the given device (address, gateway,
+    /// nameservers). Returns `None` when the device has no active IPv4 config.
+    pub async fn get_ip4_info(&self, device_path: &str) -> Result<Option<Ip4Info>> {
+        let device_proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            device_path,
+            "org.freedesktop.NetworkManager.Device",
+        )
+        .await?;
+
+        let ip4_path: OwnedObjectPath = device_proxy.get_property("Ip4Config").await?;
+        if ip4_path.as_str() == "/" {
+            return Ok(None);
+        }
+
+        let ip4_proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            ip4_path.as_str(),
+            "org.freedesktop.NetworkManager.IP4Config",
+        )
+        .await?;
+
+        let address_data: Vec<HashMap<String, OwnedValue>> = ip4_proxy
+            .get_property("AddressData")
+            .await
+            .unwrap_or_default();
+        let gateway: String = ip4_proxy.get_property("Gateway").await.unwrap_or_default();
+        let nameservers: Vec<HashMap<String, OwnedValue>> = ip4_proxy
+            .get_property("NameserverData")
+            .await
+            .unwrap_or_default();
+
+        let addresses = address_data
+            .into_iter()
+            .filter_map(|m| {
+                let addr: String = m.get("address")?.try_clone().ok()?.try_into().ok()?;
+                let prefix: u32 = m
+                    .get("prefix")
+                    .and_then(|v| v.try_clone().ok())
+                    .and_then(|v| v.try_into().ok())
+                    .unwrap_or(0);
+                Some((addr, prefix))
+            })
+            .collect();
+
+        let nameservers = nameservers
+            .into_iter()
+            .filter_map(|m| {
+                m.get("address")
+                    .and_then(|v| v.try_clone().ok())
+                    .and_then(|v| v.try_into().ok())
+            })
+            .collect();
+
+        Ok(Some(Ip4Info {
+            addresses,
+            gateway: if gateway.is_empty() {
+                None
+            } else {
+                Some(gateway)
+            },
+            nameservers,
+        }))
+    }
+
+    /// NetworkManager's global connectivity check. Triggers a fresh probe and
+    /// returns the result: full internet, captive portal, limited, or none.
+    pub async fn check_connectivity(&self) -> Result<Connectivity> {
+        let proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            NM_PATH,
+            "org.freedesktop.NetworkManager",
+        )
+        .await?;
+
+        let state: u32 = proxy.call("CheckConnectivity", &()).await?;
+        Ok(Connectivity::from(state))
+    }
+
     /// Get device state
     pub async fn get_device_state(&self, device_path: &str) -> Result<DeviceState> {
         let proxy = Proxy::new(

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -2,6 +2,67 @@
 
 use std::fmt;
 
+/// Active IPv4 configuration pulled from an NM device's `Ip4Config` object.
+#[derive(Debug, Clone, Default)]
+pub struct Ip4Info {
+    pub addresses: Vec<(String, u32)>,
+    pub gateway: Option<String>,
+    pub nameservers: Vec<String>,
+}
+
+/// NetworkManager connectivity state. Mirrors `NM_CONNECTIVITY_*` values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Connectivity {
+    Unknown,
+    None,
+    Portal,
+    Limited,
+    Full,
+}
+
+impl From<u32> for Connectivity {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Connectivity::None,
+            2 => Connectivity::Portal,
+            3 => Connectivity::Limited,
+            4 => Connectivity::Full,
+            _ => Connectivity::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod connectivity_tests {
+    use super::Connectivity;
+
+    #[test]
+    fn known_nm_codes_map_correctly() {
+        assert_eq!(Connectivity::from(1), Connectivity::None);
+        assert_eq!(Connectivity::from(2), Connectivity::Portal);
+        assert_eq!(Connectivity::from(3), Connectivity::Limited);
+        assert_eq!(Connectivity::from(4), Connectivity::Full);
+    }
+
+    #[test]
+    fn unknown_codes_fall_back() {
+        assert_eq!(Connectivity::from(0), Connectivity::Unknown);
+        assert_eq!(Connectivity::from(99), Connectivity::Unknown);
+    }
+}
+
+impl fmt::Display for Connectivity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Connectivity::Unknown => write!(f, "unknown"),
+            Connectivity::None => write!(f, "no connectivity"),
+            Connectivity::Portal => write!(f, "captive portal"),
+            Connectivity::Limited => write!(f, "limited"),
+            Connectivity::Full => write!(f, "full internet"),
+        }
+    }
+}
+
 /// WiFi operation mode (replaces iwdrs::modes::Mode)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Mode {


### PR DESCRIPTION
Closes #62.

## Summary

Adds `wlctl doctor`, a CLI subcommand that walks the network stack and prints a verdict instead of raw logs.

```
$ wlctl doctor
[ok]   rfkill       not blocked
[ok]   driver       ath11k_pci loaded
[ok]   interface    wlan0 is ACTIVATED
[ok]   association  Motel6 (61% signal)
[ok]   ip address   172.17.1.117/16
[ok]   dns          resolves (1.1.1.1)
[ok]   gateway      172.17.0.1 reachable
[ok]   internet     reachable via 1.1.1.1:443
[ok]   connectivity full internet access
```

On failure, each check prints an interpreted verdict with a suggested fix.

## What's included

- `src/doctor/` — pluggable `DiagnosticCheck` trait, one check per file (rfkill, driver, device state, association, IP, DNS, gateway, internet, captive portal)
- NM helpers: `Ip4Info`, `Connectivity`, `get_ip4_info`, `check_connectivity`
- `doctor` CLI subcommand

## Follow-up

- TUI integration (keybind + modal) in a separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new wlctl "doctor" command that runs a suite of Wi‑Fi diagnostics and prints a concise status report with summaries and remediation hints.
  * Diagnostics include rfkill (hardware/software block), driver, interface state, association, IP address, DNS, gateway, internet reachability, and captive‑portal detection.

* **Changes**
  * CLI now prevents using root-level arguments together with a subcommand to avoid conflicting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->