### PR TITLE
feat: captive portal auto-login

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,9 +5,17 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::nm::{Mode, NMClient};
 
 use crate::{
-    adapter::Adapter, agent::AuthAgent, config::Config, device::Device, doctor::DoctorModal,
-    event::Event, mode::station::auth::Auth, mode::station::network::Network,
-    notification::Notification, reset::Reset,
+    adapter::Adapter,
+    agent::AuthAgent,
+    config::Config,
+    device::Device,
+    doctor::DoctorModal,
+    event::Event,
+    mode::station::auth::Auth,
+    mode::station::network::Network,
+    notification::{Notification, NotificationLevel},
+    portal::{self, PortalWatcher},
+    reset::Reset,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -48,6 +56,9 @@ pub struct App {
     /// applies results that carry the current id. Dismissing also bumps it, so
     /// in-flight results never resurrect a closed modal.
     pub doctor_run_id: u64,
+    /// Captive portal transition tracker. Idle field that only acts during
+    /// `tick()` when the current SSID transitions into a portal state.
+    pub portal_watcher: PortalWatcher,
 }
 
 impl App {
@@ -113,6 +124,7 @@ Error: {}",
             network_pending_auth: None,
             doctor: None,
             doctor_run_id: 0,
+            portal_watcher: PortalWatcher::new(),
         })
     }
 
@@ -140,7 +152,42 @@ Error: {}",
         self.device.refresh().await?;
         self.adapter.refresh().await?;
 
+        self.check_captive_portal().await;
+
         Ok(())
+    }
+
+    async fn check_captive_portal(&mut self) {
+        if !self.config.captive_portal.auto_open {
+            return;
+        }
+
+        let detected = match self
+            .portal_watcher
+            .poll(&self.client, &self.device.device_path)
+            .await
+        {
+            Ok(Some(d)) => d,
+            Ok(None) => return,
+            Err(_) => return,
+        };
+
+        self.notifications.push(Notification {
+            message: format!(
+                "Captive portal detected on '{}'. Opening browser...",
+                detected.ssid
+            ),
+            level: NotificationLevel::Info,
+            ttl: 5,
+        });
+
+        if let Err(e) = portal::launch_browser(&detected.url).await {
+            self.notifications.push(Notification {
+                message: format!("Could not launch browser: {}", e),
+                level: NotificationLevel::Error,
+                ttl: 5,
+            });
+        }
     }
 
     pub fn quit(&mut self) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,4 +18,7 @@ pub fn cli() -> Command {
             Command::new("doctor")
                 .about("Diagnose why your WiFi isn't working (rfkill, driver, DHCP, DNS, ...)"),
         )
+        .subcommand(
+            Command::new("portal").about("Detect a captive portal and open it in your browser"),
+        )
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,9 @@ pub struct Config {
 
     #[serde(default)]
     pub ap: AccessPoint,
+
+    #[serde(default)]
+    pub captive_portal: CaptivePortal,
 }
 
 fn default_switch_mode() -> char {
@@ -172,6 +175,25 @@ fn default_ap_start() -> char {
 
 fn default_ap_stop() -> char {
     'x'
+}
+
+// Captive portal
+#[derive(Deserialize, Debug)]
+pub struct CaptivePortal {
+    #[serde(default = "default_captive_portal_auto_open")]
+    pub auto_open: bool,
+}
+
+impl Default for CaptivePortal {
+    fn default() -> Self {
+        Self {
+            auto_open: default_captive_portal_auto_open(),
+        }
+    }
+}
+
+fn default_captive_portal_auto_open() -> bool {
+    true
 }
 
 impl Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub mod nm;
 
 pub mod doctor;
 
+pub mod portal;
+
 pub fn nm_network_name(name: &str) -> String {
     // NetworkManager handles SSID encoding internally, so we just return as-is
     name.to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use wlctl::{
     handler::{handle_key_events, toggle_connect},
     nm::Mode,
     notification::{Notification, NotificationLevel},
-    rfkill,
+    portal, rfkill,
     tui::Tui,
 };
 
@@ -26,8 +26,10 @@ async fn main() -> Result<()> {
 
     let args = cli::cli().get_matches();
 
-    if let Some(("doctor", _)) = args.subcommand() {
-        return doctor::run().await;
+    match args.subcommand() {
+        Some(("doctor", _)) => return doctor::run().await,
+        Some(("portal", _)) => return portal::run_once().await,
+        _ => {}
     }
 
     rfkill::check()?;

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -219,6 +219,21 @@ impl NMClient {
         Ok(Connectivity::from(state))
     }
 
+    /// Fetch the URL NetworkManager probes for connectivity. Opening this URL
+    /// in a browser will be intercepted and redirected by a captive portal,
+    /// which is exactly the flow we want when auto-launching a login page.
+    pub async fn get_connectivity_check_uri(&self) -> Result<String> {
+        let proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            NM_PATH,
+            "org.freedesktop.NetworkManager",
+        )
+        .await?;
+
+        Ok(proxy.get_property("ConnectivityCheckUri").await?)
+    }
+
     /// Get device state
     pub async fn get_device_state(&self, device_path: &str) -> Result<DeviceState> {
         let proxy = Proxy::new(

--- a/src/portal/browser.rs
+++ b/src/portal/browser.rs
@@ -1,0 +1,29 @@
+use std::env;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+/// Launch the user's preferred browser pointing at `url`.
+///
+/// Resolution order:
+///  1. `$BROWSER` (if set and non-empty)
+///  2. `xdg-open` (standard Linux fallback)
+///
+/// The child process is spawned detached — we neither wait for it to exit nor
+/// pipe its stdio, so the TUI is unaffected.
+pub async fn launch(url: &str) -> Result<()> {
+    let (program, args) = match env::var("BROWSER") {
+        Ok(b) if !b.is_empty() => (b, vec![url.to_string()]),
+        _ => ("xdg-open".to_string(), vec![url.to_string()]),
+    };
+
+    Command::new(&program)
+        .args(&args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .with_context(|| format!("Failed to launch browser `{}`", program))?;
+
+    Ok(())
+}

--- a/src/portal/browser.rs
+++ b/src/portal/browser.rs
@@ -3,19 +3,23 @@ use std::env;
 use anyhow::{Context, Result};
 use tokio::process::Command;
 
+/// Fallback when `$BROWSER` is unset, empty, or contains no usable candidate.
+/// `xdg-open` itself handles desktop-environment-aware selection.
+const DEFAULT_BROWSER: &str = "xdg-open";
+
 /// Launch the user's preferred browser pointing at `url`.
 ///
 /// Resolution order:
-///  1. `$BROWSER` (if set and non-empty)
-///  2. `xdg-open` (standard Linux fallback)
+///  1. `$BROWSER` (xdg-utils convention — colon-separated list of candidates,
+///     each of which may carry its own args; we take the first non-empty
+///     candidate and delegate further fallback to the system)
+///  2. `xdg-open` when the env var is unset, empty, or all-whitespace
 ///
 /// The child process is spawned detached — we neither wait for it to exit nor
 /// pipe its stdio, so the TUI is unaffected.
 pub async fn launch(url: &str) -> Result<()> {
-    let (program, args) = match env::var("BROWSER") {
-        Ok(b) if !b.is_empty() => (b, vec![url.to_string()]),
-        _ => ("xdg-open".to_string(), vec![url.to_string()]),
-    };
+    let (program, mut args) = resolve_command(env::var("BROWSER").ok());
+    args.push(url.to_string());
 
     Command::new(&program)
         .args(&args)
@@ -26,4 +30,95 @@ pub async fn launch(url: &str) -> Result<()> {
         .with_context(|| format!("Failed to launch browser `{}`", program))?;
 
     Ok(())
+}
+
+/// Parse the value of `$BROWSER` into a program path plus any leading args,
+/// honouring the xdg-utils convention: colons separate fallback candidates,
+/// whitespace within a candidate separates program from args.
+///
+/// Pure function so it's unit-testable without touching the process env.
+fn resolve_command(browser_env: Option<String>) -> (String, Vec<String>) {
+    let candidate = browser_env
+        .as_deref()
+        .and_then(|raw| raw.split(':').map(str::trim).find(|s| !s.is_empty()));
+
+    let Some(cmd) = candidate else {
+        return (DEFAULT_BROWSER.to_string(), Vec::new());
+    };
+
+    let mut parts = cmd.split_whitespace();
+    // Invariant: `cmd` is the result of `find(|s| !s.is_empty())` on trimmed
+    // slices, so at least one whitespace-separated token exists.
+    let program = parts
+        .next()
+        .expect("candidate survived non-empty filter")
+        .to_string();
+    let args = parts.map(str::to_string).collect();
+    (program, args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_falls_back_to_xdg_open() {
+        assert_eq!(resolve_command(None), ("xdg-open".into(), vec![]));
+    }
+
+    #[test]
+    fn empty_or_whitespace_falls_back() {
+        assert_eq!(
+            resolve_command(Some("".into())),
+            ("xdg-open".into(), vec![])
+        );
+        assert_eq!(
+            resolve_command(Some("   ".into())),
+            ("xdg-open".into(), vec![])
+        );
+    }
+
+    #[test]
+    fn plain_program_has_no_args() {
+        assert_eq!(
+            resolve_command(Some("firefox".into())),
+            ("firefox".into(), vec![])
+        );
+    }
+
+    #[test]
+    fn whitespace_separates_program_from_args() {
+        assert_eq!(
+            resolve_command(Some("firefox --private-window".into())),
+            ("firefox".into(), vec!["--private-window".into()])
+        );
+    }
+
+    #[test]
+    fn colon_picks_first_candidate() {
+        assert_eq!(
+            resolve_command(Some("firefox:chromium".into())),
+            ("firefox".into(), vec![])
+        );
+        assert_eq!(
+            resolve_command(Some("firefox --new-tab:chromium".into())),
+            ("firefox".into(), vec!["--new-tab".into()])
+        );
+    }
+
+    #[test]
+    fn colon_skips_empty_candidates() {
+        assert_eq!(
+            resolve_command(Some(":firefox".into())),
+            ("firefox".into(), vec![])
+        );
+        assert_eq!(
+            resolve_command(Some("  :  :firefox".into())),
+            ("firefox".into(), vec![])
+        );
+        assert_eq!(
+            resolve_command(Some("::".into())),
+            (DEFAULT_BROWSER.into(), vec![])
+        );
+    }
 }

--- a/src/portal/mod.rs
+++ b/src/portal/mod.rs
@@ -40,34 +40,55 @@ impl PortalWatcher {
 
     /// Poll connectivity and report a new portal if we just entered the Portal
     /// state on an SSID we haven't auto-opened for yet.
+    ///
+    /// State (`previous_state`, `opened_for`) is committed only after all
+    /// required lookups succeed. A transient D-Bus error leaves the watcher
+    /// eligible to retry on the next tick — otherwise a single failed SSID
+    /// lookup would mark the portal transition as already handled and the
+    /// auto-open would never fire for that session.
     pub async fn poll(
         &mut self,
         nm: &Arc<NMClient>,
         device_path: &str,
     ) -> Result<Option<PortalDetected>> {
         let state = nm.check_connectivity().await?;
-        let previous = self.previous_state.replace(state);
 
+        // Leaving Portal (or never entered): safe to record — re-entry will
+        // flow back through the transition branch below.
         if state != Connectivity::Portal {
-            return Ok(None);
-        }
-        if previous == Some(Connectivity::Portal) {
+            self.previous_state = Some(state);
             return Ok(None);
         }
 
+        // Already in Portal on the previous tick — no transition to report.
+        if self.previous_state == Some(Connectivity::Portal) {
+            return Ok(None);
+        }
+
+        // Fresh Portal transition. Gather details before committing any
+        // state; transient lookup failures fall through without mutation so
+        // the next tick re-evaluates the same transition.
         let ssid = match nm.get_connected_ssid(device_path).await {
             Ok(Some(s)) => s,
             _ => return Ok(None),
         };
 
-        if !self.opened_for.insert(ssid.clone()) {
+        if self.opened_for.contains(&ssid) {
+            // Already handled this SSID this session; record the Portal state
+            // so subsequent ticks short-circuit on the "previous == Portal"
+            // guard above instead of re-entering this branch.
+            self.previous_state = Some(Connectivity::Portal);
             return Ok(None);
         }
 
-        let url = nm.get_connectivity_check_uri().await.unwrap_or_default();
+        let url = nm.get_connectivity_check_uri().await?;
         if url.is_empty() {
             return Ok(None);
         }
+
+        // All lookups succeeded — commit the transition.
+        self.previous_state = Some(Connectivity::Portal);
+        self.opened_for.insert(ssid.clone());
 
         Ok(Some(PortalDetected { ssid, url }))
     }

--- a/src/portal/mod.rs
+++ b/src/portal/mod.rs
@@ -66,11 +66,12 @@ impl PortalWatcher {
         }
 
         // Fresh Portal transition. Gather details before committing any
-        // state; transient lookup failures fall through without mutation so
-        // the next tick re-evaluates the same transition.
-        let ssid = match nm.get_connected_ssid(device_path).await {
-            Ok(Some(s)) => s,
-            _ => return Ok(None),
+        // state; transient lookup failures propagate via `?` (caller decides
+        // how to react) so the next tick re-evaluates the same transition.
+        // `Ok(None)` — no SSID currently associated — is a legitimate no-op,
+        // distinct from a D-Bus failure, so we return cleanly without error.
+        let Some(ssid) = nm.get_connected_ssid(device_path).await? else {
+            return Ok(None);
         };
 
         if self.opened_for.contains(&ssid) {

--- a/src/portal/mod.rs
+++ b/src/portal/mod.rs
@@ -1,0 +1,147 @@
+//! Captive-portal detection.
+//!
+//! A `PortalWatcher` polls NetworkManager's connectivity state each tick and
+//! emits an event when a fresh portal is encountered on the current SSID.
+//! The watcher itself is passive — it only reports state transitions. The
+//! action (notify the user, open a browser) is the caller's responsibility.
+
+mod browser;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::nm::{Connectivity, NMClient};
+
+pub use browser::launch as launch_browser;
+
+/// Emitted by the watcher when a new captive portal is detected — i.e. when
+/// the connectivity state transitions from non-`Portal` to `Portal` on an SSID
+/// we haven't opened this session yet.
+#[derive(Debug, Clone)]
+pub struct PortalDetected {
+    pub ssid: String,
+    pub url: String,
+}
+
+pub struct PortalWatcher {
+    previous_state: Option<Connectivity>,
+    opened_for: HashSet<String>,
+}
+
+impl PortalWatcher {
+    pub fn new() -> Self {
+        Self {
+            previous_state: None,
+            opened_for: HashSet::new(),
+        }
+    }
+
+    /// Poll connectivity and report a new portal if we just entered the Portal
+    /// state on an SSID we haven't auto-opened for yet.
+    pub async fn poll(
+        &mut self,
+        nm: &Arc<NMClient>,
+        device_path: &str,
+    ) -> Result<Option<PortalDetected>> {
+        let state = nm.check_connectivity().await?;
+        let previous = self.previous_state.replace(state);
+
+        if state != Connectivity::Portal {
+            return Ok(None);
+        }
+        if previous == Some(Connectivity::Portal) {
+            return Ok(None);
+        }
+
+        let ssid = match nm.get_connected_ssid(device_path).await {
+            Ok(Some(s)) => s,
+            _ => return Ok(None),
+        };
+
+        if !self.opened_for.insert(ssid.clone()) {
+            return Ok(None);
+        }
+
+        let url = nm.get_connectivity_check_uri().await.unwrap_or_default();
+        if url.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(PortalDetected { ssid, url }))
+    }
+}
+
+impl Default for PortalWatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One-shot detection used by the `wlctl portal` CLI subcommand. Probes
+/// connectivity, launches the browser if a portal is detected, and returns
+/// a user-facing message.
+pub async fn run_once() -> Result<()> {
+    use anyhow::Context;
+
+    let nm = Arc::new(
+        NMClient::new()
+            .await
+            .context("Could not reach NetworkManager over D-Bus")?,
+    );
+
+    let state = nm.check_connectivity().await?;
+
+    match state {
+        Connectivity::Portal => {
+            let url = nm.get_connectivity_check_uri().await?;
+            if url.is_empty() {
+                anyhow::bail!(
+                    "NetworkManager reports a captive portal but has no probe URL configured."
+                );
+            }
+            println!(
+                "Captive portal detected. Opening {} in your browser...",
+                url
+            );
+            launch_browser(&url).await?;
+        }
+        Connectivity::Full => println!("No portal — you have full internet access."),
+        Connectivity::Limited => println!("Connected but no internet (limited)."),
+        Connectivity::None => println!("No connectivity."),
+        Connectivity::Unknown => println!("Connectivity state unknown."),
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn watcher_with(prev: Connectivity, opened: &[&str]) -> PortalWatcher {
+        PortalWatcher {
+            previous_state: Some(prev),
+            opened_for: opened.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn opened_for_tracks_per_ssid() {
+        let mut w = watcher_with(Connectivity::Full, &[]);
+        assert!(w.opened_for.insert("work".into()));
+        assert!(!w.opened_for.insert("work".into()));
+        assert!(w.opened_for.insert("home".into()));
+    }
+
+    #[test]
+    fn event_construction() {
+        let e = PortalDetected {
+            ssid: "Hotel-Guest".into(),
+            url: "http://example/probe".into(),
+        };
+        assert_eq!(e.ssid, "Hotel-Guest");
+        assert_eq!(e.url, "http://example/probe");
+    }
+}


### PR DESCRIPTION
Closes #61.

## Summary

When NetworkManager reports `Connectivity=PORTAL`, `wlctl` now opens the probe URL in the user's browser automatically. The portal's HTTP redirect sends them to the login page.

## What's included

- `PortalWatcher` — tracks state transitions and a per-session SSID ignore-list so we never spam
- `launch_browser` — resolves `$BROWSER` then falls back to `xdg-open`; child is fully detached
- TUI integration: `App::tick()` polls the watcher and pushes a notification when a new portal is detected
- `wlctl portal` subcommand — one-shot manual trigger for scripting
- `captive_portal.auto_open` config toggle (default `true`) to disable the background behavior

## Follow-ups (not in this PR)

- Per-SSID credential memory so returning hotel guests are re-authenticated silently (mentioned in #61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic captive-portal detection that notifies users and, when detected, attempts to open the portal URL in the browser.
  * New CLI subcommand to detect and open a captive portal on demand for one-shot checks.

* **Configuration**
  * New optional setting to enable/disable automatic captive-portal detection and auto-opening (enabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->