### PR TITLE
chore(release): v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "wlctl"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wlctl"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Aashish Thapa"]
 license = "GPL-3.0"
 edition = "2024"

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,6 @@
 <div align="center">
   <h1>wlctl</h1>
-  <h3>TUI for managing WiFi using NetworkManager</h3>
-  <p>A fork of <a href="https://github.com/pythops/impala">impala</a> that uses NetworkManager instead of iwd</p>
+  <p>WiFi TUI for NetworkManager.</p>
 
   [![CI](https://github.com/aashish-thapa/wlctl/actions/workflows/ci.yaml/badge.svg)](https://github.com/aashish-thapa/wlctl/actions/workflows/ci.yaml)
   [![Crates.io](https://img.shields.io/crates/v/wlctl.svg)](https://crates.io/crates/wlctl)
@@ -9,156 +8,106 @@
   [![License](https://img.shields.io/crates/l/wlctl.svg)](https://github.com/aashish-thapa/wlctl/blob/main/LICENSE)
 </div>
 
-## Purpose
+![demo](https://github.com/user-attachments/assets/55c800ff-d0aa-4454-aa6b-3990833ce530)
 
-I personally love impala but it has limitation due to use of iwd. So, this repo preserves the beauty but changes the underlying logic to use NetworkManager.
+## Why
 
-## 📸 Demo
+[impala](https://github.com/pythops/impala) is a great wifi TUI but it talks to `iwd`. If your distro already runs NetworkManager (most do — GNOME, KDE, Ubuntu, Fedora, Pop, …), you can't drop impala in without ripping the stack out. wlctl keeps the impala UX and points it at NetworkManager, so it just works alongside what your DE is already doing.
 
-![](https://github.com/user-attachments/assets/55c800ff-d0aa-4454-aa6b-3990833ce530)
+## Features
 
-## ✨ Features
+- Station and Access Point modes
+- WPA Enterprise (802.1X)
+- Multiple adapters — pick which one to drive, switch on the fly
+- `wlctl doctor` — walks rfkill, driver, association, IP, DHCP, gateway, DNS, internet
+- QR code sharing, hidden networks, speed test
+- Vim keys, every binding configurable
 
-- WPA Enterprise (802.1X) Support
-- Station & Access Point Modes
-- QR Code Network Sharing
-- **Uses NetworkManager** - works alongside your existing network setup
+## Install
 
-## 💡 Prerequisites
-
-- A Linux based OS
-- [NetworkManager](https://networkmanager.dev/) running
-- [nerdfonts](https://www.nerdfonts.com/) (Optional) for icons
-
-> [!NOTE]
-> This fork uses NetworkManager instead of iwd, so it works with your existing network configuration without conflicts.
-
-## 🚀 Installation
-
-### 📦 crates.io
-
-You can install `wlctl` from [crates.io](https://crates.io/crates/wlctl)
-
-```shell
+```sh
+# crates.io
 cargo install wlctl
-```
-## Arch Linux (AUR)
 
-`wlctl-bin` is available on the Arch User Repository.
-
-```bash
+# Arch (AUR)
 yay -S wlctl-bin
-```
 
-### ⚒️ Build from source
-
-Run the following command:
-
-```shell
-git clone https://github.com/aashish-thapa/wlctl
-cd wlctl
+# from source
+git clone https://github.com/aashish-thapa/wlctl && cd wlctl
 cargo build --release
 ```
 
-This will produce an executable file at `target/release/wlctl` that you can copy to a directory in your `$PATH`.
+Needs NetworkManager running. [Nerd Fonts](https://www.nerdfonts.com/) optional, for icons.
 
-## 🪄 Usage
+## Usage
 
-### Global
+`wlctl` to launch the TUI. `wlctl doctor` when something's broken and you want to know which layer.
 
-`Tab` or `Shift + Tab`: Switch between different sections.
+| Action | Key |
+|---|---|
+| Switch panel | `Tab` / `Shift+Tab` |
+| Move | `j` `k` / arrows |
+| Scan | `s` |
+| Connect / disconnect | `Space` or `Enter` |
+| Hidden network | `h` |
+| Toggle auto-connect | `t` |
+| Forget network | `d` |
+| Show all known | `a` |
+| QR share | `p` |
+| Speed test (needs `speedtest-cli`) | `Shift+S` |
+| Device info | `i` |
+| Toggle power | `o` |
+| Switch adapter mode | `Ctrl+R` |
+| Doctor | `?` |
+| Quit | `q` / `Ctrl+C` |
+| Dismiss popup | `Esc` |
 
-`j` or `Down` : Scroll down.
+## Config
 
-`k` or `Up`: Scroll up.
-
-`ctrl+r`: Switch adapter mode.
-
-`?`: Show help.
-
-`esc`: Dismiss the different pop-ups.
-
-`q` or `ctrl+c`: Quit the app. (Note: `<Esc>` can also quit if `esc_quit = true` is set in config)
-
-### Device
-
-`i`: Show device information.
-
-`o`: Toggle device power.
-
-### Station
-
-`s`: Start scanning.
-
-`Space or Enter`: Connect/Disconnect the network.
-
-### New Networks
-
-`h`: Connect to a hidden network.
-
-### Known Networks
-
-`t`: Enable/Disable auto-connect.
-
-`d`: Remove the network from the known networks list.
-
-`a`: Show all the known networks.
-
-`p`: Share via QR Code.
-
-`Shift + s`: Speed test 
-> [!NOTE]
-> `speedtest-cli` is used. Install it with `pip install speedtest-cli`
-
-### Access Point
-
-`n`: Start a new access point.
-
-`x`: Stop the running access point.
-
-## Custom keybindings
-
-Keybindings can be customized in the config file `$HOME/.config/wlctl/config.toml`
+`~/.config/wlctl/config.toml`. All keys rebindable.
 
 ```toml
 switch = "r"
 mode = "station"
-esc_quit = false  # Set to true to enable Esc key to quit the app
+esc_quit = false
 
 [device]
 infos = "i"
 toggle_power = "o"
-
-[access_point]
-start = 'n'
-stop = 'x'
+doctor = "?"
 
 [station]
 toggle_scanning = "s"
-
-[station.new_network]
-show_all = "a"
-connect_hidden = "h"
 
 [station.known_network]
 toggle_autoconnect = "t"
 remove = "d"
 show_all = "a"
 share = "p"
+speed_test = "S"
+
+[station.new_network]
+show_all = "a"
+connect_hidden = "h"
+
+[access_point]
+start = "n"
+stop = "x"
 ```
 
-## Differences from upstream impala
+## vs. impala
 
-| Feature | impala (upstream) | wlctl (this fork) |
-|---------|-------------------|-------------------|
+|  | impala | wlctl |
+|---|---|---|
 | Backend | iwd | NetworkManager |
-| Config location | `/var/lib/iwd/` | `/etc/NetworkManager/system-connections/` |
-| Conflicts | Conflicts with NetworkManager | Works alongside existing setup |
+| Coexists with default desktop network stack | no | yes |
+| Multi-adapter selector | — | yes |
+| `doctor` subcommand | — | yes |
 
 ## Credits
 
-This is a fork of [pythops/impala](https://github.com/pythops/impala). All credit for the original UI and architecture goes to the original author.
+Forked from [pythops/impala](https://github.com/pythops/impala). UI and architecture are theirs.
 
-## ⚖️ License
+## License
 
 GPLv3


### PR DESCRIPTION
## Summary
- Bump `Cargo.toml` and `Cargo.lock` to `0.1.6`
- Ships everything merged to main since `v0.1.5`: multi-adapter selector, `wlctl doctor` (subcommand + in-app modal), doctor robustness fixes, NetworkManager IP4Config error propagation, Readme rewrite

## Test plan
- [x] CI green
- [ ] Smoke: launch TUI, switch adapters, run `wlctl doctor`, trigger doctor modal with `?`
- [ ] After merge: tag `v0.1.6` on main to fire the release action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.6

* **Documentation**
  * Restructured README with table-driven layout for improved readability
  * Added demo image reference
  * Simplified installation instructions and keybindings quick reference
  * Updated configuration examples with new keybinding options
  * Enhanced product comparison section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->