### PR TITLE
fix(rfkill): only abort on hard block, let soft block recover in-app

### DIFF
--- a/src/rfkill.rs
+++ b/src/rfkill.rs
@@ -16,22 +16,17 @@ pub fn check() -> Result<()> {
                 let state = fs::read_to_string(state_path)?.trim().parse::<u8>()?;
 
                 // https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-rfkill
-                match state {
-                    0 => {
-                        eprintln!(
-                            r"
-The wifi device is soft blocked
-Run the following command to unblock it
-$ sudo rfkill unblock wlan
-                    "
-                        );
-                        std::process::exit(1);
-                    }
-                    2 => {
-                        eprintln!("The wifi device is hard blocked");
-                        std::process::exit(1);
-                    }
-                    _ => {}
+                //
+                // Only a hard block (state 2, physical/BIOS kill switch) is
+                // fatal: software can't clear it. A soft block (state 0) is
+                // usually NetworkManager's own block from a prior power-off, so
+                // let the app launch — it shows the device as off, and toggling
+                // power re-enables wireless over D-Bus (no sudo, no rfkill).
+                if state == 2 {
+                    eprintln!(
+                        "The wifi device is hard blocked. Enable it with the hardware switch or in BIOS."
+                    );
+                    std::process::exit(1);
                 }
                 break;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved radio frequency kill (rfkill) state detection to distinguish between soft-block and hard-block conditions, treating only the hard-block case as a fatal error while allowing soft-block to continue functioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aashish-thapa/wlctl/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->