### PR TITLE
feat(vpn): manage profiles + import WireGuard configs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,12 +81,12 @@ Needs NetworkManager running. [Nerd Fonts](https://www.nerdfonts.com/) optional,
 | Toggle on / off | `Space` or `Enter` |
 | Toggle autoconnect | `a` |
 | Delete profile (confirm `y`/`n`) | `d` |
-| Import a WireGuard `.conf` | `i` |
+| Import a WireGuard config | `i` |
 | Close | `Esc` |
 
 The selected tunnel's assigned IP and uptime show below the list while it's up.
 
-**Importing WireGuard configs**: press `i`, type (or paste) the path to a WireGuard `.conf` file (e.g. one from Proton, Mullvad), and press Enter. wlctl parses it and creates a NetworkManager profile — no `nmcli` needed. `~` is expanded. The profile is added without auto-connecting; toggle it on with Enter. OpenVPN `.ovpn` files aren't supported here — import those with `nmcli connection import type openvpn file <path>` (requires the `NetworkManager-openvpn` plugin).
+**Importing WireGuard configs**: press `i`, then either **paste the whole config** (most providers — Proton, Mullvad — just hand you the text) or type a path to a `.conf` file, and press Enter. wlctl parses it and creates a NetworkManager profile — no `nmcli` needed. Pasted configs are named after the server endpoint; file imports after the file name. `~` is expanded in paths. The profile is added without auto-connecting; toggle it on with Enter. OpenVPN `.ovpn` files aren't supported here — import those with `nmcli connection import type openvpn file <path>` (requires the `NetworkManager-openvpn` plugin).
 
 ### Device panel
 

--- a/Readme.md
+++ b/Readme.md
@@ -81,9 +81,12 @@ Needs NetworkManager running. [Nerd Fonts](https://www.nerdfonts.com/) optional,
 | Toggle on / off | `Space` or `Enter` |
 | Toggle autoconnect | `a` |
 | Delete profile (confirm `y`/`n`) | `d` |
+| Import a WireGuard `.conf` | `i` |
 | Close | `Esc` |
 
 The selected tunnel's assigned IP and uptime show below the list while it's up.
+
+**Importing WireGuard configs**: press `i`, type (or paste) the path to a WireGuard `.conf` file (e.g. one from Proton, Mullvad), and press Enter. wlctl parses it and creates a NetworkManager profile — no `nmcli` needed. `~` is expanded. The profile is added without auto-connecting; toggle it on with Enter. OpenVPN `.ovpn` files aren't supported here — import those with `nmcli connection import type openvpn file <path>` (requires the `NetworkManager-openvpn` plugin).
 
 ### Device panel
 

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@
 - Station and Access Point modes
 - WPA Enterprise (802.1X)
 - Multiple adapters — pick which one to drive, switch on the fly
-- VPN connections — toggle saved VPN / WireGuard profiles, like nmtui
+- VPN connections — toggle, manage autoconnect, and delete saved VPN / WireGuard profiles, like nmtui; an active tunnel shows as a badge in the top-right
 - `wlctl doctor` — walks rfkill, driver, association, IP, DHCP, gateway, DNS, internet
 - QR code sharing, hidden networks, speed test
 - Vim keys, every binding configurable
@@ -73,6 +73,17 @@ Needs NetworkManager running. [Nerd Fonts](https://www.nerdfonts.com/) optional,
 | Connect / disconnect | `Space` or `Enter` |
 | Connect to hidden | `h` |
 | Show all | `a` |
+
+### VPN connections (open with `v`)
+
+| Action | Key |
+|---|---|
+| Toggle on / off | `Space` or `Enter` |
+| Toggle autoconnect | `a` |
+| Delete profile (confirm `y`/`n`) | `d` |
+| Close | `Esc` |
+
+The selected tunnel's assigned IP and uptime show below the list while it's up.
 
 ### Device panel
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -161,6 +161,9 @@ pub struct App {
     /// Open VPN modal, if any. Refreshed each tick while open so on/off state
     /// stays live as tunnels come up and down.
     pub vpn: Option<VpnModal>,
+    /// Names of currently-active VPN/WireGuard tunnels, refreshed each tick.
+    /// Drives the always-on status badge regardless of whether the modal is open.
+    pub active_vpns: Vec<String>,
 }
 
 impl App {
@@ -225,6 +228,7 @@ Error: {}",
             doctor: None,
             doctor_run_id: 0,
             vpn: None,
+            active_vpns: Vec::new(),
         })
     }
 
@@ -373,6 +377,12 @@ Error: {}",
         // Keep the VPN modal's on/off state live while it's open.
         if let Some(modal) = &mut self.vpn {
             modal.refresh(&self.client).await?;
+        }
+
+        // Refresh the always-on VPN badge. Best-effort: a transient D-Bus error
+        // shouldn't take down the whole tick, so failures just leave it stale.
+        if let Ok(names) = self.client.get_active_vpn_names().await {
+            self.active_vpns = names;
         }
 
         Ok(())

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,6 +15,7 @@ pub enum Event {
     Tick,
     Key(KeyEvent),
     Mouse(MouseEvent),
+    Paste(String),
     Resize(u16, u16),
     Notification(Notification),
     Reset(Mode),
@@ -67,6 +68,11 @@ impl EventHandler {
                       },
                       CrosstermEvent::Resize(x, y) => {
                         sender_cloned.send(Event::Resize(x, y)).unwrap();
+                      },
+                      // Only emitted while bracketed paste is enabled (scoped to
+                      // the VPN config import field).
+                      CrosstermEvent::Paste(text) => {
+                        sender_cloned.send(Event::Paste(text)).unwrap();
                       },
                       _ => {}
                     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -158,6 +158,50 @@ async fn handle_vpn_keys(
         return Ok(());
     };
 
+    // While importing, the modal is a path input field: capture all keys.
+    if modal.import_input.is_some() {
+        match key_event.code {
+            KeyCode::Esc => modal.import_input = None,
+            KeyCode::Backspace => {
+                if let Some(buf) = &mut modal.import_input {
+                    buf.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if let Some(buf) = &mut modal.import_input {
+                    buf.push(c);
+                }
+            }
+            KeyCode::Enter => {
+                let path = modal
+                    .import_input
+                    .take()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    match crate::vpn::import_from_file(&app.client, &path).await {
+                        Ok(id) => {
+                            Notification::send(
+                                format!("Imported VPN {id}"),
+                                notification::NotificationLevel::Info,
+                                sender,
+                            )?;
+                            modal.refresh(&app.client).await?;
+                        }
+                        Err(e) => Notification::send(
+                            format!("Import failed: {e}"),
+                            notification::NotificationLevel::Error,
+                            sender,
+                        )?,
+                    }
+                }
+            }
+            _ => {}
+        }
+        return Ok(());
+    }
+
     // A pending delete confirmation captures all keys until resolved.
     if modal.pending_delete {
         match key_event.code {
@@ -238,6 +282,7 @@ async fn handle_vpn_keys(
                 modal.pending_delete = true;
             }
         }
+        KeyCode::Char('i') => modal.import_input = Some(String::new()),
         _ => {}
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -12,7 +12,10 @@ use crate::mode::station::speed_test::SpeedTest;
 use crate::nm::{Mode, SecurityType};
 use crate::notification::{self, Notification};
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{
+    DisableBracketedPaste, EnableBracketedPaste, KeyCode, KeyEvent, KeyModifiers,
+};
+use crossterm::execute;
 use tokio::sync::mpsc::UnboundedSender;
 use tui_input::backend::crossterm::EventHandler;
 
@@ -146,6 +149,30 @@ async fn open_vpn(app: &mut App, sender: &UnboundedSender<Event>) {
     }
 }
 
+/// Toggles terminal bracketed paste. Enabled only while the VPN import field is
+/// open so a pasted config arrives as one `Event::Paste`; the rest of the app
+/// keeps its plain key-flood paste behavior. Best-effort — failure just means
+/// pasting won't be captured, while typing still works.
+fn set_bracketed_paste(on: bool) {
+    let mut out = std::io::stdout();
+    let _ = if on {
+        execute!(out, EnableBracketedPaste)
+    } else {
+        execute!(out, DisableBracketedPaste)
+    };
+}
+
+/// Appends pasted text to the VPN import field when it's open. Lets users paste
+/// a whole WireGuard config (or a path) instead of typing it.
+pub fn handle_paste(app: &mut App, text: String) {
+    if app.focused_block == FocusedBlock::Vpn
+        && let Some(modal) = &mut app.vpn
+        && let Some(buf) = &mut modal.import_input
+    {
+        buf.push_str(&text);
+    }
+}
+
 /// Handles keys while the VPN modal is open: navigate, toggle the selected
 /// tunnel, or close. Toggling re-reads state so the row reflects the change
 /// without waiting for the next tick.
@@ -158,10 +185,14 @@ async fn handle_vpn_keys(
         return Ok(());
     };
 
-    // While importing, the modal is a path input field: capture all keys.
+    // While importing, the modal captures all keys: type/paste a file path or a
+    // full WireGuard config, Enter to import, Esc to cancel.
     if modal.import_input.is_some() {
         match key_event.code {
-            KeyCode::Esc => modal.import_input = None,
+            KeyCode::Esc => {
+                modal.import_input = None;
+                set_bracketed_paste(false);
+            }
             KeyCode::Backspace => {
                 if let Some(buf) = &mut modal.import_input {
                     buf.pop();
@@ -173,14 +204,18 @@ async fn handle_vpn_keys(
                 }
             }
             KeyCode::Enter => {
-                let path = modal
-                    .import_input
-                    .take()
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-                if !path.is_empty() {
-                    match crate::vpn::import_from_file(&app.client, &path).await {
+                let raw = modal.import_input.take().unwrap_or_default();
+                set_bracketed_paste(false);
+                let input = raw.trim();
+                if !input.is_empty() {
+                    // A pasted config contains an [Interface] section; anything
+                    // else is treated as a path to a `.conf` file.
+                    let result = if input.to_ascii_lowercase().contains("[interface]") {
+                        crate::vpn::import_from_text(&app.client, input).await
+                    } else {
+                        crate::vpn::import_from_file(&app.client, input).await
+                    };
+                    match result {
                         Ok(id) => {
                             Notification::send(
                                 format!("Imported VPN {id}"),
@@ -282,7 +317,10 @@ async fn handle_vpn_keys(
                 modal.pending_delete = true;
             }
         }
-        KeyCode::Char('i') => modal.import_input = Some(String::new()),
+        KeyCode::Char('i') => {
+            modal.import_input = Some(String::new());
+            set_bracketed_paste(true);
+        }
         _ => {}
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -158,6 +158,32 @@ async fn handle_vpn_keys(
         return Ok(());
     };
 
+    // A pending delete confirmation captures all keys until resolved.
+    if modal.pending_delete {
+        match key_event.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                match modal.delete_selected(&app.client).await {
+                    Ok(Some(id)) => Notification::send(
+                        format!("Deleted VPN {id}"),
+                        notification::NotificationLevel::Info,
+                        sender,
+                    )?,
+                    Ok(None) => {}
+                    Err(e) => Notification::send(
+                        format!("Delete failed: {e}"),
+                        notification::NotificationLevel::Error,
+                        sender,
+                    )?,
+                }
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                modal.pending_delete = false;
+            }
+            _ => {}
+        }
+        return Ok(());
+    }
+
     match key_event.code {
         KeyCode::Esc => {
             app.vpn = None;
@@ -192,6 +218,24 @@ async fn handle_vpn_keys(
                         sender,
                     )?;
                 }
+            }
+        }
+        KeyCode::Char('a') => match modal.toggle_autoconnect(&app.client).await {
+            Ok(Some((id, on))) => Notification::send(
+                format!("Autoconnect {} for {id}", if on { "on" } else { "off" }),
+                notification::NotificationLevel::Info,
+                sender,
+            )?,
+            Ok(None) => {}
+            Err(e) => Notification::send(
+                format!("Autoconnect change failed: {e}"),
+                notification::NotificationLevel::Error,
+                sender,
+            )?,
+        },
+        KeyCode::Char('d') => {
+            if modal.selected_entry().is_some() {
+                modal.pending_delete = true;
             }
         }
         _ => {}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -12,10 +12,7 @@ use crate::mode::station::speed_test::SpeedTest;
 use crate::nm::{Mode, SecurityType};
 use crate::notification::{self, Notification};
 
-use crossterm::event::{
-    DisableBracketedPaste, EnableBracketedPaste, KeyCode, KeyEvent, KeyModifiers,
-};
-use crossterm::execute;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tokio::sync::mpsc::UnboundedSender;
 use tui_input::backend::crossterm::EventHandler;
 
@@ -149,27 +146,13 @@ async fn open_vpn(app: &mut App, sender: &UnboundedSender<Event>) {
     }
 }
 
-/// Toggles terminal bracketed paste. Enabled only while the VPN import field is
-/// open so a pasted config arrives as one `Event::Paste`; the rest of the app
-/// keeps its plain key-flood paste behavior. Best-effort — failure just means
-/// pasting won't be captured, while typing still works.
-fn set_bracketed_paste(on: bool) {
-    let mut out = std::io::stdout();
-    let _ = if on {
-        execute!(out, EnableBracketedPaste)
-    } else {
-        execute!(out, DisableBracketedPaste)
-    };
-}
-
 /// Appends pasted text to the VPN import field when it's open. Lets users paste
-/// a whole WireGuard config (or a path) instead of typing it.
+/// a whole WireGuard config (or a path) instead of typing it. No-op otherwise.
 pub fn handle_paste(app: &mut App, text: String) {
     if app.focused_block == FocusedBlock::Vpn
         && let Some(modal) = &mut app.vpn
-        && let Some(buf) = &mut modal.import_input
     {
-        buf.push_str(&text);
+        modal.import_append(&text);
     }
 }
 
@@ -186,49 +169,39 @@ async fn handle_vpn_keys(
     };
 
     // While importing, the modal captures all keys: type/paste a file path or a
-    // full WireGuard config, Enter to import, Esc to cancel.
-    if modal.import_input.is_some() {
+    // full WireGuard config, Enter to import, Esc to cancel. (Bracketed paste is
+    // enabled by the main loop while this prompt is open.)
+    if modal.import_buffer().is_some() {
         match key_event.code {
-            KeyCode::Esc => {
-                modal.import_input = None;
-                set_bracketed_paste(false);
-            }
-            KeyCode::Backspace => {
-                if let Some(buf) = &mut modal.import_input {
-                    buf.pop();
-                }
-            }
-            KeyCode::Char(c) => {
-                if let Some(buf) = &mut modal.import_input {
-                    buf.push(c);
-                }
-            }
+            KeyCode::Esc => modal.cancel_prompt(),
+            KeyCode::Backspace => modal.import_backspace(),
+            KeyCode::Char(c) => modal.import_append(c.encode_utf8(&mut [0u8; 4])),
             KeyCode::Enter => {
-                let raw = modal.import_input.take().unwrap_or_default();
-                set_bracketed_paste(false);
-                let input = raw.trim();
-                if !input.is_empty() {
-                    // A pasted config contains an [Interface] section; anything
-                    // else is treated as a path to a `.conf` file.
-                    let result = if input.to_ascii_lowercase().contains("[interface]") {
-                        crate::vpn::import_from_text(&app.client, input).await
-                    } else {
-                        crate::vpn::import_from_file(&app.client, input).await
-                    };
-                    match result {
-                        Ok(id) => {
-                            Notification::send(
-                                format!("Imported VPN {id}"),
-                                notification::NotificationLevel::Info,
+                if let Some(raw) = modal.take_import() {
+                    let input = raw.trim();
+                    if !input.is_empty() {
+                        // A pasted config contains an [Interface] section;
+                        // anything else is treated as a path to a `.conf` file.
+                        let result = if input.to_ascii_lowercase().contains("[interface]") {
+                            crate::vpn::import_from_text(&app.client, input).await
+                        } else {
+                            crate::vpn::import_from_file(&app.client, input).await
+                        };
+                        match result {
+                            Ok(id) => {
+                                Notification::send(
+                                    format!("Imported VPN {id}"),
+                                    notification::NotificationLevel::Info,
+                                    sender,
+                                )?;
+                                modal.refresh(&app.client).await?;
+                            }
+                            Err(e) => Notification::send(
+                                format!("Import failed: {e}"),
+                                notification::NotificationLevel::Error,
                                 sender,
-                            )?;
-                            modal.refresh(&app.client).await?;
+                            )?,
                         }
-                        Err(e) => Notification::send(
-                            format!("Import failed: {e}"),
-                            notification::NotificationLevel::Error,
-                            sender,
-                        )?,
                     }
                 }
             }
@@ -238,10 +211,10 @@ async fn handle_vpn_keys(
     }
 
     // A pending delete confirmation captures all keys until resolved.
-    if modal.pending_delete {
+    if modal.pending_delete().is_some() {
         match key_event.code {
             KeyCode::Char('y') | KeyCode::Char('Y') => {
-                match modal.delete_selected(&app.client).await {
+                match modal.delete_confirmed(&app.client).await {
                     Ok(Some(id)) => Notification::send(
                         format!("Deleted VPN {id}"),
                         notification::NotificationLevel::Info,
@@ -255,9 +228,7 @@ async fn handle_vpn_keys(
                     )?,
                 }
             }
-            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                modal.pending_delete = false;
-            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => modal.cancel_prompt(),
             _ => {}
         }
         return Ok(());
@@ -312,15 +283,8 @@ async fn handle_vpn_keys(
                 sender,
             )?,
         },
-        KeyCode::Char('d') => {
-            if modal.selected_entry().is_some() {
-                modal.pending_delete = true;
-            }
-        }
-        KeyCode::Char('i') => {
-            modal.import_input = Some(String::new());
-            set_bracketed_paste(true);
-        }
+        KeyCode::Char('d') => modal.begin_delete(),
+        KeyCode::Char('i') => modal.begin_import(),
         _ => {}
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use wlctl::{
     config::Config,
     doctor,
     event::{Event, EventHandler},
-    handler::{handle_key_events, toggle_connect},
+    handler::{handle_key_events, handle_paste, toggle_connect},
     nm::Mode,
     notification::{Notification, NotificationLevel},
     rfkill,
@@ -84,6 +84,10 @@ async fn main() -> Result<()> {
                     config.clone(),
                 )
                 .await;
+            }
+
+            Event::Paste(text) => {
+                handle_paste(&mut app, text);
             }
 
             Event::Notification(notification) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,8 +66,23 @@ async fn main() -> Result<()> {
 
     let mut exit_error_message = None;
 
+    // Tracks whether terminal bracketed paste is currently enabled. It's scoped
+    // to the VPN import field so pastes elsewhere keep their default behavior.
+    let mut bracketed_paste = false;
+
     while app.running {
         tui.draw(&mut app)?;
+
+        // Keep bracketed paste in sync with whether a text-input prompt is open.
+        let want_paste = app
+            .vpn
+            .as_ref()
+            .is_some_and(|m| m.import_buffer().is_some());
+        if want_paste != bracketed_paste {
+            let _ = tui.set_bracketed_paste(want_paste);
+            bracketed_paste = want_paste;
+        }
+
         match tui.events.next().await? {
             Event::Tick => {
                 if let Err(e) = app.tick().await {

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -37,14 +37,15 @@ fn setting_u64(section: &HashMap<String, OwnedValue>, key: &str) -> Option<u64> 
     u64::try_from(value).ok()
 }
 
-/// Encodes the IPv4 entries of `dns` for NM's `ipv4.dns` property (`au`). Each
-/// address is the host-order `in_addr` — i.e. the 4 octets `a.b.c.d` packed as
-/// `a | b<<8 | c<<16 | d<<24` — which is what libnm expects on little-endian
-/// hosts (every platform NetworkManager runs on). IPv6 entries are skipped.
+/// Encodes the IPv4 entries of `dns` for NM's `ipv4.dns` property (`au`). NM
+/// stores each value straight into an `in_addr_t`, so the integer's in-memory
+/// bytes must equal the address in network order — that's the native-endian
+/// reading of the octets (`from_ne_bytes`), correct on both little- and
+/// big-endian hosts. IPv6 entries are skipped.
 fn ipv4_dns_words(dns: &[IpAddr]) -> Vec<u32> {
     dns.iter()
         .filter_map(|ip| match ip {
-            IpAddr::V4(v) => Some(u32::from_le_bytes(v.octets())),
+            IpAddr::V4(v) => Some(u32::from_ne_bytes(v.octets())),
             IpAddr::V6(_) => None,
         })
         .collect()
@@ -1351,10 +1352,10 @@ mod dns_encoding_tests {
     use std::str::FromStr;
 
     #[test]
-    fn ipv4_dns_words_packs_octets_low_to_high() {
-        // 1.2.3.4 -> a | b<<8 | c<<16 | d<<24
+    fn ipv4_dns_words_use_native_in_addr_order() {
+        // The encoded u32's in-memory bytes must equal the address octets.
         let dns = [IpAddr::from_str("1.2.3.4").unwrap()];
-        assert_eq!(ipv4_dns_words(&dns), vec![0x04_03_02_01]);
+        assert_eq!(ipv4_dns_words(&dns)[0].to_ne_bytes(), [1, 2, 3, 4]);
         // IPv6 entries are skipped.
         let mixed = [
             IpAddr::from_str("10.2.0.1").unwrap(),
@@ -1362,7 +1363,7 @@ mod dns_encoding_tests {
         ];
         assert_eq!(
             ipv4_dns_words(&mixed),
-            vec![u32::from_le_bytes([10, 2, 0, 1])]
+            vec![u32::from_ne_bytes([10, 2, 0, 1])]
         );
     }
 

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -37,6 +37,30 @@ fn setting_u64(section: &HashMap<String, OwnedValue>, key: &str) -> Option<u64> 
     u64::try_from(value).ok()
 }
 
+/// Encodes the IPv4 entries of `dns` for NM's `ipv4.dns` property (`au`). Each
+/// address is the host-order `in_addr` — i.e. the 4 octets `a.b.c.d` packed as
+/// `a | b<<8 | c<<16 | d<<24` — which is what libnm expects on little-endian
+/// hosts (every platform NetworkManager runs on). IPv6 entries are skipped.
+fn ipv4_dns_words(dns: &[IpAddr]) -> Vec<u32> {
+    dns.iter()
+        .filter_map(|ip| match ip {
+            IpAddr::V4(v) => Some(u32::from_le_bytes(v.octets())),
+            IpAddr::V6(_) => None,
+        })
+        .collect()
+}
+
+/// Encodes the IPv6 entries of `dns` for NM's `ipv6.dns` property (`aay`): each
+/// address as its 16 raw bytes. IPv4 entries are skipped.
+fn ipv6_dns_bytes(dns: &[IpAddr]) -> Vec<Vec<u8>> {
+    dns.iter()
+        .filter_map(|ip| match ip {
+            IpAddr::V6(v) => Some(v.octets().to_vec()),
+            IpAddr::V4(_) => None,
+        })
+        .collect()
+}
+
 /// Main NetworkManager client
 #[derive(Clone, Debug)]
 pub struct NMClient {
@@ -523,6 +547,7 @@ impl NMClient {
                 id: setting_str(connection, "id").unwrap_or_default(),
                 uuid: setting_str(connection, "uuid").unwrap_or_default(),
                 kind,
+                interface_name: setting_str(connection, "interface-name").unwrap_or_default(),
                 // NetworkManager omits `autoconnect` when it's at its default of true.
                 autoconnect: setting_bool(connection, "autoconnect").unwrap_or(true),
                 timestamp: setting_u64(connection, "timestamp").unwrap_or(0),
@@ -672,16 +697,7 @@ impl NMClient {
         } else {
             ipv4.insert("method", Value::from("manual"));
             ipv4.insert("address-data", Value::from(v4));
-            // NM's ipv4.dns is `au`: each address as the 4 octets read as a
-            // native-endian u32 (i.e. network byte order on the wire).
-            let dns4: Vec<u32> = cfg
-                .dns
-                .iter()
-                .filter_map(|ip| match ip {
-                    IpAddr::V4(v) => Some(u32::from_le_bytes(v.octets())),
-                    IpAddr::V6(_) => None,
-                })
-                .collect();
+            let dns4 = ipv4_dns_words(&cfg.dns);
             if !dns4.is_empty() {
                 ipv4.insert("dns", Value::from(dns4));
             }
@@ -697,6 +713,10 @@ impl NMClient {
         } else {
             ipv6.insert("method", Value::from("manual"));
             ipv6.insert("address-data", Value::from(v6));
+            let dns6 = ipv6_dns_bytes(&cfg.dns);
+            if !dns6.is_empty() {
+                ipv6.insert("dns", Value::from(dns6));
+            }
         }
         settings.insert("ipv6", ipv6);
 
@@ -1321,5 +1341,41 @@ impl NMClient {
             .await?;
 
         Ok(result.1)
+    }
+}
+
+#[cfg(test)]
+mod dns_encoding_tests {
+    use super::{ipv4_dns_words, ipv6_dns_bytes};
+    use std::net::IpAddr;
+    use std::str::FromStr;
+
+    #[test]
+    fn ipv4_dns_words_packs_octets_low_to_high() {
+        // 1.2.3.4 -> a | b<<8 | c<<16 | d<<24
+        let dns = [IpAddr::from_str("1.2.3.4").unwrap()];
+        assert_eq!(ipv4_dns_words(&dns), vec![0x04_03_02_01]);
+        // IPv6 entries are skipped.
+        let mixed = [
+            IpAddr::from_str("10.2.0.1").unwrap(),
+            IpAddr::from_str("fd00::1").unwrap(),
+        ];
+        assert_eq!(
+            ipv4_dns_words(&mixed),
+            vec![u32::from_le_bytes([10, 2, 0, 1])]
+        );
+    }
+
+    #[test]
+    fn ipv6_dns_bytes_emits_16_raw_bytes() {
+        let mixed = [
+            IpAddr::from_str("10.2.0.1").unwrap(),
+            IpAddr::from_str("fd00::1").unwrap(),
+        ];
+        let out = ipv6_dns_bytes(&mixed);
+        assert_eq!(out.len(), 1, "IPv4 entries are skipped");
+        assert_eq!(out[0].len(), 16);
+        assert_eq!(out[0][0], 0xfd);
+        assert_eq!(out[0][15], 0x01);
     }
 }

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -22,6 +22,20 @@ fn setting_str(section: &HashMap<String, OwnedValue>, key: &str) -> Option<Strin
     String::try_from(value).ok()
 }
 
+/// Reads a boolean field out of one NetworkManager settings section, returning
+/// `None` if the key is absent or not bool-convertible.
+fn setting_bool(section: &HashMap<String, OwnedValue>, key: &str) -> Option<bool> {
+    let value = section.get(key)?.try_clone().ok()?;
+    bool::try_from(value).ok()
+}
+
+/// Reads a `u64` field out of one NetworkManager settings section, returning
+/// `None` if the key is absent or not convertible.
+fn setting_u64(section: &HashMap<String, OwnedValue>, key: &str) -> Option<u64> {
+    let value = section.get(key)?.try_clone().ok()?;
+    u64::try_from(value).ok()
+}
+
 /// Main NetworkManager client
 #[derive(Clone, Debug)]
 pub struct NMClient {
@@ -508,11 +522,82 @@ impl NMClient {
                 id: setting_str(connection, "id").unwrap_or_default(),
                 uuid: setting_str(connection, "uuid").unwrap_or_default(),
                 kind,
+                // NetworkManager omits `autoconnect` when it's at its default of true.
+                autoconnect: setting_bool(connection, "autoconnect").unwrap_or(true),
+                timestamp: setting_u64(connection, "timestamp").unwrap_or(0),
             });
         }
 
         vpns.sort_by_key(|v| v.id.to_lowercase());
         Ok(vpns)
+    }
+
+    /// Names of the VPN / WireGuard profiles that are currently activated.
+    /// Drives the always-on VPN indicator without opening the modal.
+    pub async fn get_active_vpn_names(&self) -> Result<Vec<String>> {
+        let mut names = Vec::new();
+
+        for active_path in self.get_active_connections().await? {
+            let Ok(info) = self.get_active_connection_info(active_path.as_str()).await else {
+                continue;
+            };
+            if info.state != ActiveConnectionState::Activated {
+                continue;
+            }
+            let Ok(settings) = self.get_connection_settings(&info.connection_path).await else {
+                continue;
+            };
+            let is_vpn = settings
+                .get("connection")
+                .and_then(|c| setting_str(c, "type"))
+                .is_some_and(|t| t == "vpn" || t == "wireguard");
+            if is_vpn {
+                names.push(info.id);
+            }
+        }
+
+        names.sort_by_key(|n| n.to_lowercase());
+        Ok(names)
+    }
+
+    /// First IPv4 address (as `addr/prefix`) assigned to an active connection,
+    /// read from its `Ip4Config`. `None` when the tunnel carries no IPv4 lease.
+    pub async fn active_connection_ipv4(&self, active_conn_path: &str) -> Result<Option<String>> {
+        let proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            active_conn_path,
+            "org.freedesktop.NetworkManager.Connection.Active",
+        )
+        .await?;
+
+        let ip4_path: OwnedObjectPath = proxy.get_property("Ip4Config").await?;
+        if ip4_path.as_str() == "/" {
+            return Ok(None);
+        }
+
+        let ip4_proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            ip4_path.as_str(),
+            "org.freedesktop.NetworkManager.IP4Config",
+        )
+        .await?;
+
+        let address_data: Vec<HashMap<String, OwnedValue>> =
+            ip4_proxy.get_property("AddressData").await?;
+
+        let first = address_data.into_iter().find_map(|m| {
+            let addr: String = m.get("address")?.try_clone().ok()?.try_into().ok()?;
+            let prefix: u32 = m
+                .get("prefix")
+                .and_then(|v| v.try_clone().ok())
+                .and_then(|v| v.try_into().ok())
+                .unwrap_or(0);
+            Some(format!("{addr}/{prefix}"))
+        });
+
+        Ok(first)
     }
 
     /// Connect to a network using an existing connection profile

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use std::collections::HashMap;
+use std::net::IpAddr;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 use zbus::{Connection, Proxy};
 
@@ -598,6 +599,109 @@ impl NMClient {
         });
 
         Ok(first)
+    }
+
+    /// Creates a NetworkManager `wireguard` profile from a parsed `.conf`,
+    /// without activating it. Secrets (private/preshared keys) are stored
+    /// system-owned (flags `0`) so the tunnel can come up headlessly. Returns
+    /// the new connection's object path.
+    pub async fn add_wireguard_connection(
+        &self,
+        id: &str,
+        interface: &str,
+        cfg: &WgConfig,
+    ) -> Result<OwnedObjectPath> {
+        let proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            "/org/freedesktop/NetworkManager/Settings",
+            "org.freedesktop.NetworkManager.Settings",
+        )
+        .await?;
+
+        let mut settings: HashMap<&str, HashMap<&str, Value>> = HashMap::new();
+
+        // connection
+        let mut conn: HashMap<&str, Value> = HashMap::new();
+        conn.insert("type", Value::from("wireguard"));
+        conn.insert("id", Value::from(id.to_string()));
+        conn.insert("interface-name", Value::from(interface.to_string()));
+        // Don't surprise-connect on import; the user toggles it in the modal.
+        conn.insert("autoconnect", Value::from(false));
+        settings.insert("connection", conn);
+
+        // wireguard (single peer)
+        let mut peer: HashMap<&str, Value> = HashMap::new();
+        peer.insert("public-key", Value::from(cfg.peer.public_key.clone()));
+        if let Some(endpoint) = &cfg.peer.endpoint {
+            peer.insert("endpoint", Value::from(endpoint.clone()));
+        }
+        peer.insert("allowed-ips", Value::from(cfg.peer.allowed_ips.clone()));
+        if let Some(psk) = &cfg.peer.preshared_key {
+            peer.insert("preshared-key", Value::from(psk.clone()));
+            peer.insert("preshared-key-flags", Value::from(0u32));
+        }
+        if let Some(keepalive) = cfg.peer.persistent_keepalive {
+            peer.insert("persistent-keepalive", Value::from(keepalive));
+        }
+
+        let mut wireguard: HashMap<&str, Value> = HashMap::new();
+        wireguard.insert("private-key", Value::from(cfg.private_key.clone()));
+        wireguard.insert("private-key-flags", Value::from(0u32));
+        wireguard.insert("peers", Value::from(vec![peer]));
+        settings.insert("wireguard", wireguard);
+
+        // Split interface addresses by family for the ipv4/ipv6 sections.
+        let mut v4: Vec<HashMap<&str, Value>> = Vec::new();
+        let mut v6: Vec<HashMap<&str, Value>> = Vec::new();
+        for (ip, prefix) in &cfg.addresses {
+            let mut entry: HashMap<&str, Value> = HashMap::new();
+            entry.insert("address", Value::from(ip.to_string()));
+            entry.insert("prefix", Value::from(u32::from(*prefix)));
+            if ip.is_ipv4() {
+                v4.push(entry);
+            } else {
+                v6.push(entry);
+            }
+        }
+
+        // ipv4
+        let mut ipv4: HashMap<&str, Value> = HashMap::new();
+        if v4.is_empty() {
+            ipv4.insert("method", Value::from("disabled"));
+        } else {
+            ipv4.insert("method", Value::from("manual"));
+            ipv4.insert("address-data", Value::from(v4));
+            // NM's ipv4.dns is `au`: each address as the 4 octets read as a
+            // native-endian u32 (i.e. network byte order on the wire).
+            let dns4: Vec<u32> = cfg
+                .dns
+                .iter()
+                .filter_map(|ip| match ip {
+                    IpAddr::V4(v) => Some(u32::from_le_bytes(v.octets())),
+                    IpAddr::V6(_) => None,
+                })
+                .collect();
+            if !dns4.is_empty() {
+                ipv4.insert("dns", Value::from(dns4));
+            }
+        }
+        settings.insert("ipv4", ipv4);
+
+        // ipv6
+        let mut ipv6: HashMap<&str, Value> = HashMap::new();
+        if v6.is_empty() {
+            // Match nmcli: a v4-only tunnel disables IPv6 rather than attempting
+            // SLAAC on the interface.
+            ipv6.insert("method", Value::from("disabled"));
+        } else {
+            ipv6.insert("method", Value::from("manual"));
+            ipv6.insert("address-data", Value::from(v6));
+        }
+        settings.insert("ipv6", ipv6);
+
+        let path: OwnedObjectPath = proxy.call("AddConnection", &(settings,)).await?;
+        Ok(path)
     }
 
     /// Connect to a network using an existing connection profile

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -313,6 +313,10 @@ pub struct VpnConnectionInfo {
     pub id: String,
     pub uuid: String,
     pub kind: VpnKind,
+    /// Whether NetworkManager brings this profile up automatically.
+    pub autoconnect: bool,
+    /// Epoch seconds of the profile's last successful activation (`0` if never).
+    pub timestamp: u64,
 }
 
 /// Active connection state

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -1,6 +1,29 @@
 // NetworkManager types and enums
 
 use std::fmt;
+use std::net::IpAddr;
+
+/// A WireGuard peer parsed from a `.conf` `[Peer]` section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgPeerConfig {
+    pub public_key: String,
+    pub endpoint: Option<String>,
+    pub allowed_ips: Vec<String>,
+    pub preshared_key: Option<String>,
+    pub persistent_keepalive: Option<u32>,
+}
+
+/// A WireGuard tunnel parsed from a `.conf` file, ready to be turned into a
+/// NetworkManager `wireguard` connection. Holds a single peer (the common case
+/// for hosted providers like Proton/Mullvad).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgConfig {
+    pub private_key: String,
+    /// Interface addresses as (ip, prefix); may mix IPv4 and IPv6.
+    pub addresses: Vec<(IpAddr, u8)>,
+    pub dns: Vec<IpAddr>,
+    pub peer: WgPeerConfig,
+}
 
 /// Active IPv4 configuration pulled from an NM device's `Ip4Config` object.
 #[derive(Debug, Clone, Default)]

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -336,6 +336,10 @@ pub struct VpnConnectionInfo {
     pub id: String,
     pub uuid: String,
     pub kind: VpnKind,
+    /// NetworkManager interface name (`connection.interface-name`); empty when
+    /// the profile doesn't pin one. Used to avoid interface-name collisions on
+    /// import.
+    pub interface_name: String,
     /// Whether NetworkManager brings this profile up automatically.
     pub autoconnect: bool,
     /// Epoch seconds of the profile's last successful activation (`0` if never).

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,7 +7,7 @@ use ratatui::{
     Terminal,
     backend::Backend,
     crossterm::{
-        event::{DisableBracketedPaste, DisableMouseCapture},
+        event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste},
         terminal::{self, LeaveAlternateScreen},
     },
 };
@@ -61,6 +61,18 @@ impl<B: Backend> Tui<B> {
     pub fn exit(&mut self) -> Result<()> {
         Self::reset()?;
         self.terminal.show_cursor()?;
+        Ok(())
+    }
+
+    /// Enables or disables terminal bracketed paste. Used to scope paste capture
+    /// to text-input contexts (e.g. the VPN config import field) so a paste
+    /// arrives as a single event instead of a flood of key presses.
+    pub fn set_bracketed_paste(&self, enabled: bool) -> Result<()> {
+        if enabled {
+            ratatui::crossterm::execute!(io::stdout(), EnableBracketedPaste)?;
+        } else {
+            ratatui::crossterm::execute!(io::stdout(), DisableBracketedPaste)?;
+        }
         Ok(())
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,7 +7,7 @@ use ratatui::{
     Terminal,
     backend::Backend,
     crossterm::{
-        event::DisableMouseCapture,
+        event::{DisableBracketedPaste, DisableMouseCapture},
         terminal::{self, LeaveAlternateScreen},
     },
 };
@@ -47,7 +47,14 @@ impl<B: Backend> Tui<B> {
 
     fn reset() -> Result<()> {
         terminal::disable_raw_mode()?;
-        ratatui::crossterm::execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+        // DisableBracketedPaste is harmless if it was never enabled; it ensures
+        // the terminal isn't left in bracketed-paste mode after an import.
+        ratatui::crossterm::execute!(
+            io::stdout(),
+            LeaveAlternateScreen,
+            DisableMouseCapture,
+            DisableBracketedPaste
+        )?;
         Ok(())
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,13 @@
 use std::sync::atomic::Ordering;
 
 use crate::nm::Mode;
-use ratatui::Frame;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style, Stylize},
+    text::Line,
+    widgets::{Clear, Paragraph},
+};
 
 use crate::app::{AdapterView, App, FocusedBlock};
 
@@ -98,9 +104,46 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             req.render(frame);
         }
 
+        render_vpn_badge(frame, &app.active_vpns);
+
         // Notifications
         for (index, notification) in app.notifications.iter().enumerate() {
             notification.render(index, frame);
         }
     }
+}
+
+/// Draws a small always-on badge in the top-right when one or more VPN tunnels
+/// are active, so the status is visible without opening the modal. ASCII keeps
+/// the rendered width exact for tight placement over the top border.
+fn render_vpn_badge(frame: &mut Frame, active_vpns: &[String]) {
+    let Some(first) = active_vpns.first() else {
+        return;
+    };
+
+    let extra = active_vpns.len().saturating_sub(1);
+    let label = if extra > 0 {
+        format!(" VPN: {first} +{extra} ")
+    } else {
+        format!(" VPN: {first} ")
+    };
+
+    let full = frame.area();
+    let width = (label.chars().count() as u16).min(full.width);
+    if width == 0 {
+        return;
+    }
+
+    let area = Rect {
+        x: full.width.saturating_sub(width),
+        y: 0,
+        width,
+        height: 1,
+    };
+
+    let badge = Paragraph::new(Line::from(label))
+        .style(Style::default().fg(Color::Green).bg(Color::Black).bold());
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(badge, area);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -114,8 +114,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 }
 
 /// Draws a small always-on badge in the top-right when one or more VPN tunnels
-/// are active, so the status is visible without opening the modal. ASCII keeps
-/// the rendered width exact for tight placement over the top border.
+/// are active, so the status is visible without opening the modal. The rect is
+/// sized to the label's display width (profile names may contain wide chars).
 fn render_vpn_badge(frame: &mut Frame, active_vpns: &[String]) {
     let Some(first) = active_vpns.first() else {
         return;
@@ -129,7 +129,8 @@ fn render_vpn_badge(frame: &mut Frame, active_vpns: &[String]) {
     };
 
     let full = frame.area();
-    let width = (label.chars().count() as u16).min(full.width);
+    let line = Line::from(label);
+    let width = (line.width() as u16).min(full.width);
     if width == 0 {
         return;
     }
@@ -141,8 +142,8 @@ fn render_vpn_badge(frame: &mut Frame, active_vpns: &[String]) {
         height: 1,
     };
 
-    let badge = Paragraph::new(Line::from(label))
-        .style(Style::default().fg(Color::Green).bg(Color::Black).bold());
+    let badge =
+        Paragraph::new(line).style(Style::default().fg(Color::Green).bg(Color::Black).bold());
 
     frame.render_widget(Clear, area);
     frame.render_widget(badge, area);

--- a/src/vpn/mod.rs
+++ b/src/vpn/mod.rs
@@ -224,7 +224,9 @@ pub async fn toggle(nm: &NMClient, entry: &VpnEntry) -> Result<()> {
 /// display name (derived from the file name). `~` is expanded to `$HOME`.
 pub async fn import_from_file(nm: &NMClient, path: &str) -> Result<String> {
     let expanded = expand_tilde(path);
-    let text = std::fs::read_to_string(&expanded).with_context(|| format!("reading {expanded}"))?;
+    let text = tokio::fs::read_to_string(&expanded)
+        .await
+        .with_context(|| format!("reading {expanded}"))?;
     let cfg = wg::parse(&text)?;
 
     let base = std::path::Path::new(&expanded)

--- a/src/vpn/mod.rs
+++ b/src/vpn/mod.rs
@@ -20,6 +20,8 @@ pub struct VpnEntry {
     /// Active-connection object path when the tunnel is up; used to deactivate.
     pub active_path: Option<String>,
     pub state: ActiveConnectionState,
+    /// Assigned IPv4 (`addr/prefix`) while the tunnel is up; `None` otherwise.
+    pub ipv4: Option<String>,
 }
 
 impl VpnEntry {
@@ -31,12 +33,44 @@ impl VpnEntry {
             ActiveConnectionState::Activated | ActiveConnectionState::Activating
         )
     }
+
+    /// Human-readable uptime ("up 14m", "up 2h 3m") derived from the profile's
+    /// last-activation timestamp. `None` when down or the timestamp is missing
+    /// or in the future (clock skew / never activated).
+    pub fn uptime(&self) -> Option<String> {
+        if !self.is_active() || self.info.timestamp == 0 {
+            return None;
+        }
+        let now = chrono::Local::now().timestamp();
+        let elapsed = now.checked_sub(self.info.timestamp as i64)?;
+        if elapsed < 0 {
+            return None;
+        }
+        Some(format!("up {}", format_duration(elapsed as u64)))
+    }
+}
+
+/// Formats a span of seconds compactly: "45s", "14m", "2h 3m", "1d 4h".
+fn format_duration(secs: u64) -> String {
+    let (d, h, m, s) = (secs / 86_400, secs / 3_600 % 24, secs / 60 % 60, secs % 60);
+    if d > 0 {
+        format!("{d}d {h}h")
+    } else if h > 0 {
+        format!("{h}h {m}m")
+    } else if m > 0 {
+        format!("{m}m")
+    } else {
+        format!("{s}s")
+    }
 }
 
 /// Interactive modal state: the profile list plus a selection cursor.
 pub struct VpnModal {
     pub entries: Vec<VpnEntry>,
     pub selected: usize,
+    /// When set, a delete confirmation is pending for the selected entry; the
+    /// hint line shows the prompt and only y/n are honored until resolved.
+    pub pending_delete: bool,
 }
 
 impl VpnModal {
@@ -45,6 +79,7 @@ impl VpnModal {
         Ok(Self {
             entries: list_entries(nm).await?,
             selected: 0,
+            pending_delete: false,
         })
     }
 
@@ -71,6 +106,32 @@ impl VpnModal {
         self.entries = list_entries(nm).await?;
         self.selected = self.selected.min(self.entries.len().saturating_sub(1));
         Ok(())
+    }
+
+    /// Flips autoconnect on the selected profile and re-reads state so the UI
+    /// reflects the change. No-op on an empty list.
+    pub async fn toggle_autoconnect(&mut self, nm: &NMClient) -> Result<Option<(String, bool)>> {
+        let Some(entry) = self.selected_entry() else {
+            return Ok(None);
+        };
+        let next = !entry.info.autoconnect;
+        let (path, id) = (entry.info.path.clone(), entry.info.id.clone());
+        nm.set_connection_autoconnect(&path, next).await?;
+        self.refresh(nm).await?;
+        Ok(Some((id, next)))
+    }
+
+    /// Deletes the selected profile, clearing the pending-confirm flag. Returns
+    /// the removed profile's name. No-op on an empty list.
+    pub async fn delete_selected(&mut self, nm: &NMClient) -> Result<Option<String>> {
+        self.pending_delete = false;
+        let Some(entry) = self.selected_entry() else {
+            return Ok(None);
+        };
+        let (path, id) = (entry.info.path.clone(), entry.info.id.clone());
+        nm.delete_connection(&path).await?;
+        self.refresh(nm).await?;
+        Ok(Some(id))
     }
 }
 
@@ -100,21 +161,29 @@ async fn list_entries(nm: &NMClient) -> Result<Vec<VpnEntry>> {
         }
     }
 
-    Ok(profiles
-        .into_iter()
-        .map(|info| match active_by_profile.get(&info.path) {
-            Some((active_path, state)) => VpnEntry {
-                info,
-                active_path: Some(active_path.clone()),
-                state: *state,
-            },
-            None => VpnEntry {
+    let mut entries = Vec::with_capacity(profiles.len());
+    for info in profiles {
+        match active_by_profile.get(&info.path) {
+            Some((active_path, state)) => {
+                // Best-effort: a missing lease shouldn't drop the whole entry.
+                let ipv4 = nm.active_connection_ipv4(active_path).await.ok().flatten();
+                entries.push(VpnEntry {
+                    info,
+                    active_path: Some(active_path.clone()),
+                    state: *state,
+                    ipv4,
+                });
+            }
+            None => entries.push(VpnEntry {
                 info,
                 active_path: None,
                 state: ActiveConnectionState::Deactivated,
-            },
-        })
-        .collect())
+                ipv4: None,
+            }),
+        }
+    }
+
+    Ok(entries)
 }
 
 #[cfg(test)]
@@ -133,9 +202,12 @@ mod tests {
                 id: id.to_string(),
                 uuid: id.to_string(),
                 kind: VpnKind::Vpn,
+                autoconnect: false,
+                timestamp: 0,
             },
             active_path,
             state,
+            ipv4: None,
         }
     }
 
@@ -143,6 +215,7 @@ mod tests {
         VpnModal {
             entries: states.iter().map(|s| entry("vpn", *s)).collect(),
             selected: 0,
+            pending_delete: false,
         }
     }
 
@@ -164,6 +237,29 @@ mod tests {
         assert_eq!(m.selected, 2, "wraps below zero to the last entry");
         m.move_selection(1);
         assert_eq!(m.selected, 0, "wraps past the end to the first entry");
+    }
+
+    #[test]
+    fn format_duration_picks_coarsest_units() {
+        assert_eq!(format_duration(45), "45s");
+        assert_eq!(format_duration(14 * 60), "14m");
+        assert_eq!(format_duration(2 * 3600 + 3 * 60), "2h 3m");
+        assert_eq!(format_duration(86_400 + 4 * 3600), "1d 4h");
+    }
+
+    #[test]
+    fn uptime_is_none_when_down_or_untimed() {
+        assert!(
+            entry("a", ActiveConnectionState::Deactivated)
+                .uptime()
+                .is_none()
+        );
+        // Active but no timestamp recorded.
+        assert!(
+            entry("a", ActiveConnectionState::Activated)
+                .uptime()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/vpn/mod.rs
+++ b/src/vpn/mod.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 
-use crate::nm::{ActiveConnectionState, NMClient, VpnConnectionInfo};
+use crate::nm::{ActiveConnectionState, NMClient, VpnConnectionInfo, WgConfig};
 
 /// A saved VPN profile paired with its live activation state.
 #[derive(Debug, Clone)]
@@ -72,8 +72,9 @@ pub struct VpnModal {
     /// When set, a delete confirmation is pending for the selected entry; the
     /// hint line shows the prompt and only y/n are honored until resolved.
     pub pending_delete: bool,
-    /// When set, the modal is capturing a file path to import a WireGuard
-    /// `.conf`; the hint line becomes an input field until Enter/Esc.
+    /// When set, the modal is capturing import input — either a pasted WireGuard
+    /// config or a path to a `.conf` file; the hint line becomes the input field
+    /// until Enter/Esc.
     pub import_input: Option<String>,
 }
 
@@ -155,21 +156,86 @@ pub async fn toggle(nm: &NMClient, entry: &VpnEntry) -> Result<()> {
 
 /// Reads a WireGuard `.conf` from `path`, parses it, and creates a matching
 /// NetworkManager profile (without activating it). Returns the new profile's
-/// display name. `~` is expanded to the user's home directory.
+/// display name (derived from the file name). `~` is expanded to `$HOME`.
 pub async fn import_from_file(nm: &NMClient, path: &str) -> Result<String> {
     let expanded = expand_tilde(path);
     let text = std::fs::read_to_string(&expanded).with_context(|| format!("reading {expanded}"))?;
     let cfg = wg::parse(&text)?;
 
-    let stem = std::path::Path::new(&expanded)
+    let base = std::path::Path::new(&expanded)
         .file_stem()
         .and_then(|s| s.to_str())
         .filter(|s| !s.is_empty())
         .unwrap_or("wireguard");
 
-    let interface = sanitize_ifname(stem);
-    nm.add_wireguard_connection(stem, &interface, &cfg).await?;
-    Ok(stem.to_string())
+    create_profile(nm, base, &cfg).await
+}
+
+/// Parses pasted WireGuard config text and creates a NetworkManager profile
+/// (without activating it). The display name is derived from the peer endpoint
+/// since pasted text carries no file name. Returns the new profile's name.
+pub async fn import_from_text(nm: &NMClient, text: &str) -> Result<String> {
+    let cfg = wg::parse(text)?;
+    let base = name_from_config(&cfg);
+    create_profile(nm, &base, &cfg).await
+}
+
+/// Creates the profile under a name that doesn't collide with an existing one.
+async fn create_profile(nm: &NMClient, base_name: &str, cfg: &WgConfig) -> Result<String> {
+    let id = dedupe_name(nm, base_name).await?;
+    let interface = sanitize_ifname(&id);
+    nm.add_wireguard_connection(&id, &interface, cfg).await?;
+    Ok(id)
+}
+
+/// Returns `base` if no saved VPN profile already uses it, otherwise appends a
+/// numeric suffix (`base-2`, `base-3`, …) until the name is free.
+async fn dedupe_name(nm: &NMClient, base: &str) -> Result<String> {
+    let existing: std::collections::HashSet<String> = nm
+        .get_vpn_connections()
+        .await?
+        .into_iter()
+        .map(|v| v.id)
+        .collect();
+    if !existing.contains(base) {
+        return Ok(base.to_string());
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if !existing.contains(&candidate) {
+            return Ok(candidate);
+        }
+        n += 1;
+    }
+}
+
+/// Derives a friendly profile name from the peer endpoint (e.g. `wg-nl247` from
+/// a hostname, `wg-185-185-50-27` from an IP). Falls back to `wg-imported`.
+fn name_from_config(cfg: &WgConfig) -> String {
+    let Some(endpoint) = &cfg.peer.endpoint else {
+        return "wg-imported".to_string();
+    };
+
+    // Drop the port. Handle both `host:port` and `[v6]:port`.
+    let host = if let Some(rest) = endpoint.strip_prefix('[') {
+        rest.split(']').next().unwrap_or(rest)
+    } else {
+        endpoint
+            .rsplit_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(endpoint)
+    }
+    .trim();
+
+    if host.is_empty() {
+        "wg-imported".to_string()
+    } else if host.parse::<std::net::IpAddr>().is_ok() {
+        format!("wg-{}", host.replace(['.', ':'], "-"))
+    } else {
+        let label = host.split('.').next().unwrap_or(host);
+        format!("wg-{label}")
+    }
 }
 
 /// Expands a leading `~` to `$HOME`. Leaves the path untouched otherwise.
@@ -288,6 +354,31 @@ mod tests {
     fn expand_tilde_uses_home() {
         // Non-tilde paths are returned verbatim.
         assert_eq!(expand_tilde("/etc/wg.conf"), "/etc/wg.conf");
+    }
+
+    #[test]
+    fn name_from_config_derives_from_endpoint() {
+        let make = |endpoint: Option<&str>| WgConfig {
+            private_key: "k=".into(),
+            addresses: vec![],
+            dns: vec![],
+            peer: crate::nm::WgPeerConfig {
+                public_key: "p=".into(),
+                endpoint: endpoint.map(str::to_string),
+                allowed_ips: vec![],
+                preshared_key: None,
+                persistent_keepalive: None,
+            },
+        };
+        assert_eq!(
+            name_from_config(&make(Some("185.185.50.27:51820"))),
+            "wg-185-185-50-27"
+        );
+        assert_eq!(
+            name_from_config(&make(Some("nl247.example.com:51820"))),
+            "wg-nl247"
+        );
+        assert_eq!(name_from_config(&make(None)), "wg-imported");
     }
 
     #[test]

--- a/src/vpn/mod.rs
+++ b/src/vpn/mod.rs
@@ -8,7 +8,7 @@ mod wg;
 
 pub use render::render_modal;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
 
@@ -65,17 +65,22 @@ fn format_duration(secs: u64) -> String {
     }
 }
 
-/// Interactive modal state: the profile list plus a selection cursor.
+/// A transient sub-mode layered over the list. Modeled as one enum so the modal
+/// can never be in two prompts at once, and so the delete target is captured up
+/// front (immune to the list reordering under a background refresh).
+pub enum VpnPrompt {
+    /// Awaiting y/n to delete the named profile at `path`.
+    ConfirmDelete { path: String, id: String },
+    /// Capturing import input: a pasted WireGuard config or a `.conf` path.
+    Import(String),
+}
+
+/// Interactive modal state: the profile list, a selection cursor, and an
+/// optional active prompt (delete confirmation or import input).
 pub struct VpnModal {
     pub entries: Vec<VpnEntry>,
     pub selected: usize,
-    /// When set, a delete confirmation is pending for the selected entry; the
-    /// hint line shows the prompt and only y/n are honored until resolved.
-    pub pending_delete: bool,
-    /// When set, the modal is capturing import input — either a pasted WireGuard
-    /// config or a path to a `.conf` file; the hint line becomes the input field
-    /// until Enter/Esc.
-    pub import_input: Option<String>,
+    pub prompt: Option<VpnPrompt>,
 }
 
 impl VpnModal {
@@ -84,9 +89,24 @@ impl VpnModal {
         Ok(Self {
             entries: list_entries(nm).await?,
             selected: 0,
-            pending_delete: false,
-            import_input: None,
+            prompt: None,
         })
+    }
+
+    /// The import buffer, when the import prompt is active.
+    pub fn import_buffer(&self) -> Option<&str> {
+        match &self.prompt {
+            Some(VpnPrompt::Import(buf)) => Some(buf),
+            _ => None,
+        }
+    }
+
+    /// The profile pending deletion, when the confirm prompt is active.
+    pub fn pending_delete(&self) -> Option<&str> {
+        match &self.prompt {
+            Some(VpnPrompt::ConfirmDelete { id, .. }) => Some(id),
+            _ => None,
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -127,14 +147,59 @@ impl VpnModal {
         Ok(Some((id, next)))
     }
 
-    /// Deletes the selected profile, clearing the pending-confirm flag. Returns
-    /// the removed profile's name. No-op on an empty list.
-    pub async fn delete_selected(&mut self, nm: &NMClient) -> Result<Option<String>> {
-        self.pending_delete = false;
-        let Some(entry) = self.selected_entry() else {
+    /// Arms a delete confirmation for the selected profile, capturing its path
+    /// so the eventual delete targets that profile even if the list reorders.
+    /// No-op on an empty list.
+    pub fn begin_delete(&mut self) {
+        if let Some(entry) = self.selected_entry() {
+            self.prompt = Some(VpnPrompt::ConfirmDelete {
+                path: entry.info.path.clone(),
+                id: entry.info.id.clone(),
+            });
+        }
+    }
+
+    /// Opens the import prompt with an empty buffer.
+    pub fn begin_import(&mut self) {
+        self.prompt = Some(VpnPrompt::Import(String::new()));
+    }
+
+    /// Dismisses any active prompt.
+    pub fn cancel_prompt(&mut self) {
+        self.prompt = None;
+    }
+
+    /// Appends text to the import buffer (used for pasted input and typed keys).
+    pub fn import_append(&mut self, text: &str) {
+        if let Some(VpnPrompt::Import(buf)) = &mut self.prompt {
+            buf.push_str(text);
+        }
+    }
+
+    /// Removes the last character from the import buffer.
+    pub fn import_backspace(&mut self) {
+        if let Some(VpnPrompt::Import(buf)) = &mut self.prompt {
+            buf.pop();
+        }
+    }
+
+    /// Closes the import prompt and returns the captured buffer, if any.
+    pub fn take_import(&mut self) -> Option<String> {
+        match self.prompt.take() {
+            Some(VpnPrompt::Import(buf)) => Some(buf),
+            other => {
+                self.prompt = other;
+                None
+            }
+        }
+    }
+
+    /// Deletes the profile captured by the active confirm prompt. Returns the
+    /// removed profile's name. No-op when no delete is pending.
+    pub async fn delete_confirmed(&mut self, nm: &NMClient) -> Result<Option<String>> {
+        let Some(VpnPrompt::ConfirmDelete { path, id }) = self.prompt.take() else {
             return Ok(None);
         };
-        let (path, id) = (entry.info.path.clone(), entry.info.id.clone());
         nm.delete_connection(&path).await?;
         self.refresh(nm).await?;
         Ok(Some(id))
@@ -180,31 +245,53 @@ pub async fn import_from_text(nm: &NMClient, text: &str) -> Result<String> {
     create_profile(nm, &base, &cfg).await
 }
 
-/// Creates the profile under a name that doesn't collide with an existing one.
+/// Creates the profile under a display name and interface name that don't
+/// collide with existing saved profiles. A single fetch backs both dedup checks.
 async fn create_profile(nm: &NMClient, base_name: &str, cfg: &WgConfig) -> Result<String> {
-    let id = dedupe_name(nm, base_name).await?;
-    let interface = sanitize_ifname(&id);
+    let existing = nm.get_vpn_connections().await?;
+    let ids: HashSet<&str> = existing.iter().map(|v| v.id.as_str()).collect();
+    let ifaces: HashSet<&str> = existing
+        .iter()
+        .map(|v| v.interface_name.as_str())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let id = dedupe(&ids, base_name);
+    let interface = unique_interface(&ifaces, &sanitize_ifname(base_name));
     nm.add_wireguard_connection(&id, &interface, cfg).await?;
     Ok(id)
 }
 
-/// Returns `base` if no saved VPN profile already uses it, otherwise appends a
-/// numeric suffix (`base-2`, `base-3`, …) until the name is free.
-async fn dedupe_name(nm: &NMClient, base: &str) -> Result<String> {
-    let existing: std::collections::HashSet<String> = nm
-        .get_vpn_connections()
-        .await?
-        .into_iter()
-        .map(|v| v.id)
-        .collect();
-    if !existing.contains(base) {
-        return Ok(base.to_string());
+/// Returns `base` if free in `taken`, otherwise appends `-2`, `-3`, … until the
+/// name is unique.
+fn dedupe(taken: &HashSet<&str>, base: &str) -> String {
+    if !taken.contains(base) {
+        return base.to_string();
     }
     let mut n = 2;
     loop {
         let candidate = format!("{base}-{n}");
-        if !existing.contains(&candidate) {
-            return Ok(candidate);
+        if !taken.contains(candidate.as_str()) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
+/// Like [`dedupe`] but keeps the result a valid interface name (≤15 chars) by
+/// truncating the base to make room for the numeric suffix.
+fn unique_interface(taken: &HashSet<&str>, base: &str) -> String {
+    if !taken.contains(base) {
+        return base.to_string();
+    }
+    let mut n = 2;
+    loop {
+        let suffix = format!("-{n}");
+        let keep = 15usize.saturating_sub(suffix.len());
+        let head: String = base.chars().take(keep).collect();
+        let candidate = format!("{}{suffix}", head.trim_end_matches('-'));
+        if !taken.contains(candidate.as_str()) {
+            return candidate;
         }
         n += 1;
     }
@@ -320,6 +407,7 @@ mod tests {
                 id: id.to_string(),
                 uuid: id.to_string(),
                 kind: VpnKind::Vpn,
+                interface_name: String::new(),
                 autoconnect: false,
                 timestamp: 0,
             },
@@ -333,9 +421,52 @@ mod tests {
         VpnModal {
             entries: states.iter().map(|s| entry("vpn", *s)).collect(),
             selected: 0,
-            pending_delete: false,
-            import_input: None,
+            prompt: None,
         }
+    }
+
+    fn set(items: &[&'static str]) -> HashSet<&'static str> {
+        items.iter().copied().collect()
+    }
+
+    #[test]
+    fn dedupe_appends_suffix_until_free() {
+        assert_eq!(dedupe(&set(&[]), "wg-home"), "wg-home");
+        assert_eq!(dedupe(&set(&["wg-home"]), "wg-home"), "wg-home-2");
+        assert_eq!(
+            dedupe(&set(&["wg-home", "wg-home-2"]), "wg-home"),
+            "wg-home-3"
+        );
+    }
+
+    #[test]
+    fn unique_interface_stays_within_15_chars() {
+        // Free name is returned as-is.
+        assert_eq!(unique_interface(&set(&[]), "proton-nl"), "proton-nl");
+        // Collisions get a suffix while staying a valid (<=15) interface name.
+        let taken = set(&["wg-185-185-50-2"]);
+        let out = unique_interface(&taken, "wg-185-185-50-2");
+        assert_ne!(out, "wg-185-185-50-2");
+        assert!(out.len() <= 15, "got {out:?}");
+    }
+
+    #[test]
+    fn prompt_helpers_model_one_mode_at_a_time() {
+        let mut m = modal(&[ActiveConnectionState::Deactivated]);
+        assert!(m.import_buffer().is_none() && m.pending_delete().is_none());
+
+        m.begin_import();
+        m.import_append("~/wg.conf");
+        assert_eq!(m.import_buffer(), Some("~/wg.conf"));
+        assert!(m.pending_delete().is_none());
+
+        // Opening the delete confirm replaces the import prompt (no dual state).
+        m.begin_delete();
+        assert!(m.import_buffer().is_none());
+        assert_eq!(m.pending_delete(), Some("vpn"));
+
+        m.cancel_prompt();
+        assert!(m.pending_delete().is_none());
     }
 
     #[test]

--- a/src/vpn/mod.rs
+++ b/src/vpn/mod.rs
@@ -4,12 +4,13 @@
 //! this module owns the modal state and NM orchestration.
 
 mod render;
+mod wg;
 
 pub use render::render_modal;
 
 use std::collections::HashMap;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::nm::{ActiveConnectionState, NMClient, VpnConnectionInfo};
 
@@ -71,6 +72,9 @@ pub struct VpnModal {
     /// When set, a delete confirmation is pending for the selected entry; the
     /// hint line shows the prompt and only y/n are honored until resolved.
     pub pending_delete: bool,
+    /// When set, the modal is capturing a file path to import a WireGuard
+    /// `.conf`; the hint line becomes an input field until Enter/Esc.
+    pub import_input: Option<String>,
 }
 
 impl VpnModal {
@@ -80,6 +84,7 @@ impl VpnModal {
             entries: list_entries(nm).await?,
             selected: 0,
             pending_delete: false,
+            import_input: None,
         })
     }
 
@@ -145,6 +150,53 @@ pub async fn toggle(nm: &NMClient, entry: &VpnEntry) -> Result<()> {
             nm.activate_connection(&entry.info.path, "/").await?;
             Ok(())
         }
+    }
+}
+
+/// Reads a WireGuard `.conf` from `path`, parses it, and creates a matching
+/// NetworkManager profile (without activating it). Returns the new profile's
+/// display name. `~` is expanded to the user's home directory.
+pub async fn import_from_file(nm: &NMClient, path: &str) -> Result<String> {
+    let expanded = expand_tilde(path);
+    let text = std::fs::read_to_string(&expanded).with_context(|| format!("reading {expanded}"))?;
+    let cfg = wg::parse(&text)?;
+
+    let stem = std::path::Path::new(&expanded)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("wireguard");
+
+    let interface = sanitize_ifname(stem);
+    nm.add_wireguard_connection(stem, &interface, &cfg).await?;
+    Ok(stem.to_string())
+}
+
+/// Expands a leading `~` to `$HOME`. Leaves the path untouched otherwise.
+fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return format!("{home}/{rest}");
+    }
+    path.to_string()
+}
+
+/// Derives a valid Linux interface name from a profile name: lowercased, only
+/// `[a-z0-9-]`, capped at 15 chars. Falls back to `wg0` if nothing survives.
+fn sanitize_ifname(name: &str) -> String {
+    let cleaned: String = name
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let trimmed = cleaned.trim_matches('-');
+    let capped: String = trimmed.chars().take(15).collect();
+    let capped = capped.trim_end_matches('-');
+    if capped.is_empty() {
+        "wg0".to_string()
+    } else {
+        capped.to_string()
     }
 }
 
@@ -216,7 +268,26 @@ mod tests {
             entries: states.iter().map(|s| entry("vpn", *s)).collect(),
             selected: 0,
             pending_delete: false,
+            import_input: None,
         }
+    }
+
+    #[test]
+    fn sanitize_ifname_keeps_it_valid() {
+        assert_eq!(
+            sanitize_ifname("proton-nl-NL-FREE-247"),
+            "proton-nl-NL-Fr".to_ascii_lowercase()
+        );
+        assert_eq!(sanitize_ifname("wg-proton"), "wg-proton");
+        assert_eq!(sanitize_ifname("US#FREE#55"), "us-free-55");
+        assert_eq!(sanitize_ifname("***"), "wg0");
+        assert!(sanitize_ifname("a-very-long-name-indeed").len() <= 15);
+    }
+
+    #[test]
+    fn expand_tilde_uses_home() {
+        // Non-tilde paths are returned verbatim.
+        assert_eq!(expand_tilde("/etc/wg.conf"), "/etc/wg.conf");
     }
 
     #[test]

--- a/src/vpn/render.rs
+++ b/src/vpn/render.rs
@@ -4,7 +4,7 @@ use ratatui::{
     style::{Color, Style, Stylize},
     text::{Line, Span},
     widgets::{
-        Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Table, TableState,
+        Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Table, TableState, Wrap,
     },
 };
 
@@ -18,6 +18,14 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
     frame.render_widget(Clear, area);
     frame.render_widget(vpn_block(), area);
 
+    let inner = vpn_block().inner(area);
+
+    // The import flow takes over the whole body with its own paste box.
+    if modal.import_input.is_some() {
+        render_import(frame, inner, modal);
+        return;
+    }
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
@@ -26,7 +34,7 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
             Constraint::Length(1),
             Constraint::Length(1),
         ])
-        .split(vpn_block().inner(area));
+        .split(inner);
 
     if modal.is_empty() {
         render_empty(frame, chunks[0]);
@@ -38,18 +46,72 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
     frame.render_widget(hint(modal), chunks[2]);
 }
 
-/// One-line detail for the selected entry: its assigned IPv4 and uptime while
-/// up. Doubles as the prompt label while importing. Blank when nothing is
-/// selected or the tunnel is down.
-fn detail(modal: &VpnModal) -> Paragraph<'static> {
-    if modal.import_input.is_some() {
-        return Paragraph::new(
-            "Paste a WireGuard config or type a .conf path  —  Enter to import, Esc to cancel",
-        )
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::DarkGray));
-    }
+/// Draws the WireGuard import view: instructions, a bordered paste/path box,
+/// and the action hints. Replaces the list while importing.
+fn render_import(frame: &mut Frame, area: Rect, modal: &VpnModal) {
+    let buf = modal.import_input.as_deref().unwrap_or("");
 
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // instructions
+            Constraint::Fill(1),   // input box
+            Constraint::Length(1), // actions
+        ])
+        .split(area);
+
+    let info = Paragraph::new(vec![
+        Line::from("Import a WireGuard tunnel".bold()),
+        Line::from("Paste a config, or type a path to a .conf file".fg(Color::DarkGray)),
+    ])
+    .alignment(Alignment::Center);
+    frame.render_widget(info, chunks[0]);
+
+    let looks_like_config = buf.contains('\n') || buf.to_ascii_lowercase().contains("[interface]");
+    let body: Vec<Line> = if buf.is_empty() {
+        vec![Line::from("_".fg(Color::DarkGray))]
+    } else if looks_like_config {
+        vec![
+            Line::from(vec![
+                Span::from("✓ ").fg(Color::Green).bold(),
+                Span::from("Config received").bold(),
+            ]),
+            Line::from(
+                format!("{} lines, {} bytes", buf.lines().count(), buf.len()).fg(Color::DarkGray),
+            ),
+        ]
+    } else {
+        // A typed path: show it with a cursor.
+        vec![Line::from(format!("{buf}_"))]
+    };
+
+    let box_block = Block::default()
+        .title(" config / path ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Blue))
+        .padding(Padding::horizontal(1));
+    let input = Paragraph::new(body)
+        .block(box_block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(input, chunks[1]);
+
+    let actions = Line::from(vec![
+        Span::from("⏎").bold(),
+        Span::from(" Import   "),
+        Span::from("Esc").bold(),
+        Span::from(" Cancel"),
+    ]);
+    frame.render_widget(
+        Paragraph::new(actions)
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::Blue)),
+        chunks[2],
+    );
+}
+
+/// One-line detail for the selected entry: its assigned IPv4 and uptime while
+/// up. Blank when nothing is selected or the tunnel is down.
+fn detail(modal: &VpnModal) -> Paragraph<'static> {
     let text = modal
         .selected_entry()
         .filter(|e| e.is_active())
@@ -164,31 +226,6 @@ fn render_list(frame: &mut Frame, area: Rect, modal: &VpnModal) {
 }
 
 fn hint(modal: &VpnModal) -> Paragraph<'static> {
-    // While importing, the hint line is the input field. A pasted config is
-    // multi-line, so show a summary rather than the raw text; a typed path is
-    // shown inline with a cursor.
-    if let Some(buf) = &modal.import_input {
-        let looks_like_config =
-            buf.contains('\n') || buf.to_ascii_lowercase().contains("[interface]");
-        let line = if looks_like_config {
-            Line::from(vec![
-                Span::from("Config pasted ").bold(),
-                Span::from(format!(
-                    "({} lines) — press Enter to import",
-                    buf.lines().count()
-                )),
-            ])
-        } else {
-            Line::from(vec![
-                Span::from("Path: ").bold(),
-                Span::from(format!("{buf}_")),
-            ])
-        };
-        return Paragraph::new(line)
-            .alignment(Alignment::Left)
-            .style(Style::default().fg(Color::White));
-    }
-
     // A pending delete swaps the hint line for a confirmation prompt.
     if modal.pending_delete {
         let name = modal

--- a/src/vpn/render.rs
+++ b/src/vpn/render.rs
@@ -39,8 +39,15 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
 }
 
 /// One-line detail for the selected entry: its assigned IPv4 and uptime while
-/// up. Blank when nothing is selected or the tunnel is down.
+/// up. Doubles as the prompt label while importing. Blank when nothing is
+/// selected or the tunnel is down.
 fn detail(modal: &VpnModal) -> Paragraph<'static> {
+    if modal.import_input.is_some() {
+        return Paragraph::new("Path to a WireGuard .conf  —  Enter to import, Esc to cancel")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::DarkGray));
+    }
+
     let text = modal
         .selected_entry()
         .filter(|e| e.is_active())
@@ -155,6 +162,17 @@ fn render_list(frame: &mut Frame, area: Rect, modal: &VpnModal) {
 }
 
 fn hint(modal: &VpnModal) -> Paragraph<'static> {
+    // While importing, the hint line is the path input field.
+    if let Some(buf) = &modal.import_input {
+        let line = Line::from(vec![
+            Span::from("Path: ").bold(),
+            Span::from(format!("{buf}_")),
+        ]);
+        return Paragraph::new(line)
+            .alignment(Alignment::Left)
+            .style(Style::default().fg(Color::White));
+    }
+
     // A pending delete swaps the hint line for a confirmation prompt.
     if modal.pending_delete {
         let name = modal
@@ -174,7 +192,13 @@ fn hint(modal: &VpnModal) -> Paragraph<'static> {
     }
 
     let spans = if modal.is_empty() {
-        vec![Span::from("Esc").bold(), Span::from(" Close")]
+        vec![
+            Span::from("i").bold(),
+            Span::from(" Import"),
+            Span::from(" | "),
+            Span::from("Esc").bold(),
+            Span::from(" Close"),
+        ]
     } else {
         vec![
             Span::from("↑↓").bold(),
@@ -188,6 +212,9 @@ fn hint(modal: &VpnModal) -> Paragraph<'static> {
             Span::from(" | "),
             Span::from("d").bold(),
             Span::from(" Delete"),
+            Span::from(" | "),
+            Span::from("i").bold(),
+            Span::from(" Import"),
             Span::from(" | "),
             Span::from("Esc").bold(),
             Span::from(" Close"),

--- a/src/vpn/render.rs
+++ b/src/vpn/render.rs
@@ -43,9 +43,11 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
 /// selected or the tunnel is down.
 fn detail(modal: &VpnModal) -> Paragraph<'static> {
     if modal.import_input.is_some() {
-        return Paragraph::new("Path to a WireGuard .conf  —  Enter to import, Esc to cancel")
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::DarkGray));
+        return Paragraph::new(
+            "Paste a WireGuard config or type a .conf path  —  Enter to import, Esc to cancel",
+        )
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(Color::DarkGray));
     }
 
     let text = modal
@@ -107,7 +109,7 @@ fn render_empty(frame: &mut Frame, area: Rect) {
     let p = Paragraph::new(vec![
         Line::from("No VPN connections configured.").centered(),
         Line::from(""),
-        Line::from("Add one with nmtui or your desktop's network settings.")
+        Line::from("Press 'i' to import a WireGuard config (paste or file path).")
             .centered()
             .style(Style::default().fg(Color::DarkGray)),
     ])
@@ -162,12 +164,26 @@ fn render_list(frame: &mut Frame, area: Rect, modal: &VpnModal) {
 }
 
 fn hint(modal: &VpnModal) -> Paragraph<'static> {
-    // While importing, the hint line is the path input field.
+    // While importing, the hint line is the input field. A pasted config is
+    // multi-line, so show a summary rather than the raw text; a typed path is
+    // shown inline with a cursor.
     if let Some(buf) = &modal.import_input {
-        let line = Line::from(vec![
-            Span::from("Path: ").bold(),
-            Span::from(format!("{buf}_")),
-        ]);
+        let looks_like_config =
+            buf.contains('\n') || buf.to_ascii_lowercase().contains("[interface]");
+        let line = if looks_like_config {
+            Line::from(vec![
+                Span::from("Config pasted ").bold(),
+                Span::from(format!(
+                    "({} lines) — press Enter to import",
+                    buf.lines().count()
+                )),
+            ])
+        } else {
+            Line::from(vec![
+                Span::from("Path: ").bold(),
+                Span::from(format!("{buf}_")),
+            ])
+        };
         return Paragraph::new(line)
             .alignment(Alignment::Left)
             .style(Style::default().fg(Color::White));

--- a/src/vpn/render.rs
+++ b/src/vpn/render.rs
@@ -15,13 +15,13 @@ use crate::nm::ActiveConnectionState;
 pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
     let area = popup_area(frame.area());
 
+    let block = vpn_block();
+    let inner = block.inner(area);
     frame.render_widget(Clear, area);
-    frame.render_widget(vpn_block(), area);
-
-    let inner = vpn_block().inner(area);
+    frame.render_widget(block, area);
 
     // The import flow takes over the whole body with its own paste box.
-    if modal.import_input.is_some() {
+    if modal.import_buffer().is_some() {
         render_import(frame, inner, modal);
         return;
     }
@@ -49,7 +49,7 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
 /// Draws the WireGuard import view: instructions, a bordered paste/path box,
 /// and the action hints. Replaces the list while importing.
 fn render_import(frame: &mut Frame, area: Rect, modal: &VpnModal) {
-    let buf = modal.import_input.as_deref().unwrap_or("");
+    let buf = modal.import_buffer().unwrap_or("");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -227,11 +227,7 @@ fn render_list(frame: &mut Frame, area: Rect, modal: &VpnModal) {
 
 fn hint(modal: &VpnModal) -> Paragraph<'static> {
     // A pending delete swaps the hint line for a confirmation prompt.
-    if modal.pending_delete {
-        let name = modal
-            .selected_entry()
-            .map(|e| e.info.id.clone())
-            .unwrap_or_default();
+    if let Some(name) = modal.pending_delete() {
         let line = Line::from(vec![
             Span::from(format!("Delete '{name}'?  ")),
             Span::from("y").bold(),

--- a/src/vpn/render.rs
+++ b/src/vpn/render.rs
@@ -21,7 +21,11 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
-        .constraints([Constraint::Fill(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Fill(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
         .split(vpn_block().inner(area));
 
     if modal.is_empty() {
@@ -30,7 +34,31 @@ pub fn render_modal(frame: &mut Frame, modal: &VpnModal) {
         render_list(frame, chunks[0], modal);
     }
 
-    frame.render_widget(hint(modal.is_empty()), chunks[1]);
+    frame.render_widget(detail(modal), chunks[1]);
+    frame.render_widget(hint(modal), chunks[2]);
+}
+
+/// One-line detail for the selected entry: its assigned IPv4 and uptime while
+/// up. Blank when nothing is selected or the tunnel is down.
+fn detail(modal: &VpnModal) -> Paragraph<'static> {
+    let text = modal
+        .selected_entry()
+        .filter(|e| e.is_active())
+        .map(|e| {
+            let mut parts = Vec::new();
+            if let Some(ip) = &e.ipv4 {
+                parts.push(ip.clone());
+            }
+            if let Some(up) = e.uptime() {
+                parts.push(up);
+            }
+            parts.join("  ·  ")
+        })
+        .unwrap_or_default();
+
+    Paragraph::new(text)
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(Color::DarkGray))
 }
 
 fn popup_area(full: Rect) -> Rect {
@@ -85,22 +113,40 @@ fn render_list(frame: &mut Frame, area: Rect, modal: &VpnModal) {
         .entries
         .iter()
         .map(|entry| {
+            let (auto_label, auto_color) = if entry.info.autoconnect {
+                ("✓", Color::Green)
+            } else {
+                ("·", Color::DarkGray)
+            };
             Row::new(vec![
                 Cell::from(state_label(entry.state))
                     .style(Style::default().fg(state_color(entry.state)).bold()),
                 Cell::from(Span::from(entry.info.id.clone()).bold()),
                 Cell::from(entry.info.kind.to_string()).style(Style::default().fg(Color::DarkGray)),
+                Cell::from(Line::from(auto_label).centered())
+                    .style(Style::default().fg(auto_color)),
             ])
         })
         .collect();
 
     let widths = [
-        Constraint::Length(8),
+        Constraint::Length(7),
         Constraint::Fill(1),
         Constraint::Length(10),
+        Constraint::Length(4),
     ];
 
+    let header = Row::new(vec![
+        Cell::from("STATE"),
+        Cell::from("NAME"),
+        Cell::from("TYPE"),
+        Cell::from(Line::from("AUTO").centered()),
+    ])
+    .style(Style::default().fg(Color::DarkGray))
+    .bottom_margin(1);
+
     let table = Table::new(rows, widths)
+        .header(header)
         .column_spacing(2)
         .row_highlight_style(Style::default().bg(Color::DarkGray).fg(Color::White));
 
@@ -108,8 +154,26 @@ fn render_list(frame: &mut Frame, area: Rect, modal: &VpnModal) {
     frame.render_stateful_widget(table, area, &mut state);
 }
 
-fn hint(is_empty: bool) -> Paragraph<'static> {
-    let spans = if is_empty {
+fn hint(modal: &VpnModal) -> Paragraph<'static> {
+    // A pending delete swaps the hint line for a confirmation prompt.
+    if modal.pending_delete {
+        let name = modal
+            .selected_entry()
+            .map(|e| e.info.id.clone())
+            .unwrap_or_default();
+        let line = Line::from(vec![
+            Span::from(format!("Delete '{name}'?  ")),
+            Span::from("y").bold(),
+            Span::from(" Yes  "),
+            Span::from("n").bold(),
+            Span::from(" No"),
+        ]);
+        return Paragraph::new(line)
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::Red));
+    }
+
+    let spans = if modal.is_empty() {
         vec![Span::from("Esc").bold(), Span::from(" Close")]
     } else {
         vec![
@@ -118,6 +182,12 @@ fn hint(is_empty: bool) -> Paragraph<'static> {
             Span::from(" | "),
             Span::from("⏎").bold(),
             Span::from(" Toggle"),
+            Span::from(" | "),
+            Span::from("a").bold(),
+            Span::from(" Auto"),
+            Span::from(" | "),
+            Span::from("d").bold(),
+            Span::from(" Delete"),
             Span::from(" | "),
             Span::from("Esc").bold(),
             Span::from(" Close"),

--- a/src/vpn/wg.rs
+++ b/src/vpn/wg.rs
@@ -118,18 +118,19 @@ fn parse_cidr(s: &str) -> Result<(IpAddr, u8)> {
     };
     let ip =
         IpAddr::from_str(addr_part.trim()).map_err(|_| anyhow!("invalid address '{addr_part}'"))?;
+    let max = if ip.is_ipv4() { 32 } else { 128 };
     let prefix = match prefix_part {
-        Some(p) => p
-            .trim()
-            .parse()
-            .map_err(|_| anyhow!("invalid prefix in '{s}'"))?,
-        None => {
-            if ip.is_ipv4() {
-                32
-            } else {
-                128
+        Some(p) => {
+            let prefix: u8 = p
+                .trim()
+                .parse()
+                .map_err(|_| anyhow!("invalid prefix in '{s}'"))?;
+            if prefix > max {
+                bail!("prefix /{prefix} out of range in '{s}'");
             }
+            prefix
         }
+        None => max,
     };
     Ok((ip, prefix))
 }

--- a/src/vpn/wg.rs
+++ b/src/vpn/wg.rs
@@ -24,6 +24,7 @@ pub fn parse(text: &str) -> Result<WgConfig> {
     let mut allowed_ips: Vec<String> = Vec::new();
     let mut preshared_key: Option<String> = None;
     let mut keepalive: Option<u32> = None;
+    let mut interface_count = 0;
     let mut peer_count = 0;
 
     for raw in text.lines() {
@@ -35,11 +36,20 @@ pub fn parse(text: &str) -> Result<WgConfig> {
 
         if let Some(name) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
             let name = name.trim().to_ascii_lowercase();
-            if name == "peer" {
-                peer_count += 1;
-                if peer_count > 1 {
-                    bail!("multiple [Peer] sections are not supported");
+            match name.as_str() {
+                "interface" => {
+                    interface_count += 1;
+                    if interface_count > 1 {
+                        bail!("multiple [Interface] sections are not supported");
+                    }
                 }
+                "peer" => {
+                    peer_count += 1;
+                    if peer_count > 1 {
+                        bail!("multiple [Peer] sections are not supported");
+                    }
+                }
+                _ => {}
             }
             section = Some(name);
             continue;
@@ -72,11 +82,23 @@ pub fn parse(text: &str) -> Result<WgConfig> {
             (Some("peer"), "publickey") => public_key = Some(value),
             (Some("peer"), "endpoint") => endpoint = Some(value),
             (Some("peer"), "allowedips") => {
-                allowed_ips.extend(value.split(',').map(|s| s.trim().to_string()));
+                for item in value.split(',') {
+                    let item = item.trim();
+                    if item.is_empty() {
+                        continue;
+                    }
+                    // Validate the CIDR; keep the original string for NM.
+                    parse_cidr(item)?;
+                    allowed_ips.push(item.to_string());
+                }
             }
             (Some("peer"), "presharedkey") => preshared_key = Some(value),
             (Some("peer"), "persistentkeepalive") => {
-                keepalive = value.parse().ok();
+                keepalive = Some(
+                    value
+                        .parse()
+                        .map_err(|_| anyhow!("invalid PersistentKeepalive '{value}'"))?,
+                );
             }
             _ => {}
         }
@@ -201,5 +223,35 @@ AllowedIPs = 0.0.0.0/0, ::/0
     fn rejects_multiple_peers() {
         let two = "[Interface]\nPrivateKey=k=\nAddress=10.0.0.2/32\n[Peer]\nPublicKey=p=\nEndpoint=h:1\nAllowedIPs=0.0.0.0/0\n[Peer]\nPublicKey=q=\nEndpoint=h:2\nAllowedIPs=0.0.0.0/0\n";
         assert!(parse(two).is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_interfaces() {
+        let two = "[Interface]\nPrivateKey=k=\nAddress=10.0.0.2/32\n[Interface]\nPrivateKey=k2=\nAddress=10.0.0.3/32\n[Peer]\nPublicKey=p=\nEndpoint=h:1\nAllowedIPs=0.0.0.0/0\n";
+        assert!(parse(two).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_allowed_ips_but_skips_empty_entries() {
+        // Trailing comma leaves an empty entry, which is skipped (not an error).
+        let cfg = parse(
+            "[Interface]\nPrivateKey=k=\nAddress=10.0.0.2/32\n[Peer]\nPublicKey=p=\nEndpoint=h:1\nAllowedIPs=0.0.0.0/0, ::/0,\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.peer.allowed_ips, vec!["0.0.0.0/0", "::/0"]);
+
+        // A non-CIDR entry is rejected.
+        assert!(parse(
+            "[Interface]\nPrivateKey=k=\nAddress=10.0.0.2/32\n[Peer]\nPublicKey=p=\nEndpoint=h:1\nAllowedIPs=not-an-ip\n"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_non_numeric_keepalive() {
+        assert!(parse(
+            "[Interface]\nPrivateKey=k=\nAddress=10.0.0.2/32\n[Peer]\nPublicKey=p=\nEndpoint=h:1\nAllowedIPs=0.0.0.0/0\nPersistentKeepalive=soon\n"
+        )
+        .is_err());
     }
 }

--- a/src/vpn/wg.rs
+++ b/src/vpn/wg.rs
@@ -1,0 +1,204 @@
+//! Minimal WireGuard `.conf` parser — enough to import the single-peer tunnels
+//! that hosted providers (Proton, Mullvad, …) hand out. Turns the INI-ish text
+//! into an [`nm::WgConfig`] that the NM layer maps onto a `wireguard` profile.
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use anyhow::{Result, anyhow, bail};
+
+use crate::nm::{WgConfig, WgPeerConfig};
+
+/// Parses WireGuard config text into a [`WgConfig`]. Section and key names are
+/// matched case-insensitively; comments (`#`/`;`) and blank lines are ignored.
+/// Exactly one `[Interface]` and one `[Peer]` are expected.
+pub fn parse(text: &str) -> Result<WgConfig> {
+    let mut section: Option<String> = None;
+
+    let mut private_key: Option<String> = None;
+    let mut addresses: Vec<(IpAddr, u8)> = Vec::new();
+    let mut dns: Vec<IpAddr> = Vec::new();
+
+    let mut public_key: Option<String> = None;
+    let mut endpoint: Option<String> = None;
+    let mut allowed_ips: Vec<String> = Vec::new();
+    let mut preshared_key: Option<String> = None;
+    let mut keepalive: Option<u32> = None;
+    let mut peer_count = 0;
+
+    for raw in text.lines() {
+        // Strip inline comments and surrounding whitespace.
+        let line = raw.split(['#', ';']).next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(name) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            let name = name.trim().to_ascii_lowercase();
+            if name == "peer" {
+                peer_count += 1;
+                if peer_count > 1 {
+                    bail!("multiple [Peer] sections are not supported");
+                }
+            }
+            section = Some(name);
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim().to_string();
+        if value.is_empty() {
+            continue;
+        }
+
+        match (section.as_deref(), key.as_str()) {
+            (Some("interface"), "privatekey") => private_key = Some(value),
+            (Some("interface"), "address") => {
+                for item in value.split(',') {
+                    addresses.push(parse_cidr(item.trim())?);
+                }
+            }
+            (Some("interface"), "dns") => {
+                // DNS may also list search domains; keep only IP entries.
+                for item in value.split(',') {
+                    if let Ok(ip) = IpAddr::from_str(item.trim()) {
+                        dns.push(ip);
+                    }
+                }
+            }
+            (Some("peer"), "publickey") => public_key = Some(value),
+            (Some("peer"), "endpoint") => endpoint = Some(value),
+            (Some("peer"), "allowedips") => {
+                allowed_ips.extend(value.split(',').map(|s| s.trim().to_string()));
+            }
+            (Some("peer"), "presharedkey") => preshared_key = Some(value),
+            (Some("peer"), "persistentkeepalive") => {
+                keepalive = value.parse().ok();
+            }
+            _ => {}
+        }
+    }
+
+    let private_key = private_key.ok_or_else(|| anyhow!("[Interface] is missing PrivateKey"))?;
+    if addresses.is_empty() {
+        bail!("[Interface] is missing Address");
+    }
+    let public_key = public_key.ok_or_else(|| anyhow!("[Peer] is missing PublicKey"))?;
+    if endpoint.is_none() {
+        bail!("[Peer] is missing Endpoint");
+    }
+    if allowed_ips.is_empty() {
+        // A tunnel that routes nothing is almost certainly a mistake.
+        bail!("[Peer] is missing AllowedIPs");
+    }
+
+    Ok(WgConfig {
+        private_key,
+        addresses,
+        dns,
+        peer: WgPeerConfig {
+            public_key,
+            endpoint,
+            allowed_ips,
+            preshared_key,
+            persistent_keepalive: keepalive,
+        },
+    })
+}
+
+/// Parses `addr/prefix`, defaulting the prefix to the address family's full
+/// width (`/32` for IPv4, `/128` for IPv6) when omitted.
+fn parse_cidr(s: &str) -> Result<(IpAddr, u8)> {
+    let (addr_part, prefix_part) = match s.split_once('/') {
+        Some((a, p)) => (a, Some(p)),
+        None => (s, None),
+    };
+    let ip =
+        IpAddr::from_str(addr_part.trim()).map_err(|_| anyhow!("invalid address '{addr_part}'"))?;
+    let prefix = match prefix_part {
+        Some(p) => p
+            .trim()
+            .parse()
+            .map_err(|_| anyhow!("invalid prefix in '{s}'"))?,
+        None => {
+            if ip.is_ipv4() {
+                32
+            } else {
+                128
+            }
+        }
+    };
+    Ok((ip, prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    const PROTON: &str = "\
+[Interface]
+# Key for proton
+PrivateKey = aPrivateKey=
+Address = 10.2.0.2/32
+DNS = 10.2.0.1
+
+[Peer]
+# NL-FREE#247
+PublicKey = aPublicKey=
+AllowedIPs = 0.0.0.0/0
+Endpoint = 1.2.3.4:51820
+";
+
+    #[test]
+    fn parses_a_typical_single_peer_conf() {
+        let cfg = parse(PROTON).unwrap();
+        assert_eq!(cfg.private_key, "aPrivateKey=");
+        assert_eq!(
+            cfg.addresses,
+            vec![(IpAddr::V4(Ipv4Addr::new(10, 2, 0, 2)), 32)]
+        );
+        assert_eq!(cfg.dns, vec![IpAddr::V4(Ipv4Addr::new(10, 2, 0, 1))]);
+        assert_eq!(cfg.peer.public_key, "aPublicKey=");
+        assert_eq!(cfg.peer.endpoint.as_deref(), Some("1.2.3.4:51820"));
+        assert_eq!(cfg.peer.allowed_ips, vec!["0.0.0.0/0"]);
+    }
+
+    #[test]
+    fn defaults_prefix_by_family_and_handles_lists() {
+        let cfg = parse(
+            "[Interface]
+PrivateKey = k=
+Address = 10.0.0.2, fd00::2
+[Peer]
+PublicKey = p=
+Endpoint = h:1
+AllowedIPs = 0.0.0.0/0, ::/0
+",
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.addresses,
+            vec![
+                (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 32),
+                (IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 2)), 128),
+            ]
+        );
+        assert_eq!(cfg.peer.allowed_ips, vec!["0.0.0.0/0", "::/0"]);
+    }
+
+    #[test]
+    fn rejects_missing_required_fields() {
+        assert!(parse("[Interface]\nAddress = 10.0.0.2/32\n[Peer]\nPublicKey=p=\nEndpoint=h:1\nAllowedIPs=0.0.0.0/0\n").is_err());
+        assert!(parse("[Interface]\nPrivateKey=k=\nAddress=10.0.0.2/32\n[Peer]\nEndpoint=h:1\nAllowedIPs=0.0.0.0/0\n").is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_peers() {
+        let two = "[Interface]\nPrivateKey=k=\nAddress=10.0.0.2/32\n[Peer]\nPublicKey=p=\nEndpoint=h:1\nAllowedIPs=0.0.0.0/0\n[Peer]\nPublicKey=q=\nEndpoint=h:2\nAllowedIPs=0.0.0.0/0\n";
+        assert!(parse(two).is_err());
+    }
+}


### PR DESCRIPTION
Builds on the merged VPN modal (#75).

- Toggle autoconnect (`a`) and delete profiles (`d`) from the modal
- Active tunnel shows a badge in the top-right, plus IP and uptime in the list
- Import a WireGuard config with `i` — paste it directly (what Proton/Mullvad give you) or point at a `.conf` file. No nmcli needed.

Tested against real NetworkManager. fmt + clippy -D warnings clean, 33 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toggle autoconnect for VPN profiles
  * Delete saved VPN and WireGuard profiles  
  * Import WireGuard configurations via file or text paste
  * Display active VPN tunnel as a top-right badge
  * Show tunnel's assigned IP and uptime when active
  * New keybindings: 'a' for autoconnect toggle, 'd' for delete, 'i' for import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->