### PR TITLE
feat: show and switch the internet path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Show which link carries internet traffic: when WiFi and Ethernet are both up,
+  the active default-route link is highlighted in green
+- Switch the internet path with `u` — make the Ethernet row or connected WiFi
+  the default route while keeping the other link up
+
 ## [0.1.8] - 2026-06-16
 
 ### Added

--- a/Readme.md
+++ b/Readme.md
@@ -67,9 +67,12 @@ Needs NetworkManager running. [Nerd Fonts](https://www.nerdfonts.com/) optional,
 | Connect / disconnect | `Space` or `Enter` |
 | Toggle auto-connect | `t` |
 | Forget network | `d` |
+| Make this the internet path | `u` |
 | Show all | `a` |
 | QR share | `p` |
 | Speed test (needs `speedtest-cli`) | `Shift+S` |
+
+When both WiFi and Ethernet are up, the link NetworkManager is actually routing internet over is highlighted in green. Press `u` on the Ethernet row or the connected WiFi to switch the default route to it (the other link stays up).
 
 ### New networks
 
@@ -138,6 +141,7 @@ remove = "d"
 show_all = "a"
 share = "p"
 speed_test = "S"
+prefer = "u"
 
 [station.new_network]
 show_all = "a"

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use zbus::zvariant::OwnedObjectPath;
 
-use crate::nm::{EthernetInfo, Mode, NMClient};
+use crate::nm::{EthernetInfo, Mode, NMClient, PrimaryLink};
 
 use crate::{
     adapter::Adapter, agent::AuthAgent, config::Config, device::Device, doctor::DoctorModal,
@@ -168,6 +168,9 @@ pub struct App {
     /// (not on the WiFi device) so link status stays visible even when the WiFi
     /// radio is off.
     pub ethernet: Option<EthernetInfo>,
+    /// Link NetworkManager is using as the default route, refreshed each tick.
+    /// Flags which of WiFi/Ethernet is the live internet path.
+    pub primary_link: Option<PrimaryLink>,
 }
 
 impl App {
@@ -234,6 +237,7 @@ Error: {}",
             vpn: None,
             active_vpns: Vec::new(),
             ethernet: None,
+            primary_link: None,
         })
     }
 
@@ -394,6 +398,11 @@ Error: {}",
         // of the WiFi power state so it stays visible when the radio is off.
         if let Ok(eth) = self.client.active_ethernet().await {
             self.ethernet = eth;
+        }
+
+        // Refresh which link owns the default route (the live internet path).
+        if let Ok(primary) = self.client.primary_link().await {
+            self.primary_link = primary;
         }
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,8 @@ pub struct KnownNetwork {
     pub share: char,
     #[serde(default = "default_station_speed_test")]
     pub speed_test: char,
+    #[serde(default = "default_station_prefer")]
+    pub prefer: char,
 }
 
 impl Default for KnownNetwork {
@@ -122,8 +124,13 @@ impl Default for KnownNetwork {
             show_all: 'a',
             share: 'p',
             speed_test: 'S',
+            prefer: 'u',
         }
     }
+}
+
+fn default_station_prefer() -> char {
+    'u'
 }
 
 fn default_station_speed_test() -> char {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -9,7 +9,7 @@ use crate::mode::ap::APFocusedSection;
 use crate::mode::station::KnownNetworkSelection;
 use crate::mode::station::share::Share;
 use crate::mode::station::speed_test::SpeedTest;
-use crate::nm::{Mode, SecurityType};
+use crate::nm::{LinkKind, Mode, SecurityType};
 use crate::notification::{self, Notification};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -913,6 +913,68 @@ pub async fn handle_key_events(
                                                     notification::NotificationLevel::Warning,
                                                     &sender,
                                                 )?;
+                                            }
+                                        }
+
+                                        // Prefer this link as the internet path
+                                        KeyCode::Char(c)
+                                            if c == config.station.known_network.prefer =>
+                                        {
+                                            // Only an active link can carry the
+                                            // default route: the Ethernet row, or
+                                            // the currently-connected WiFi.
+                                            let kind = match station.resolve_known_selection() {
+                                                Some(KnownNetworkSelection::Ethernet) => {
+                                                    Some(LinkKind::Ethernet)
+                                                }
+                                                Some(KnownNetworkSelection::Network(idx)) => {
+                                                    let (net, _) = &station.known_networks[idx];
+                                                    if station
+                                                        .connected_network
+                                                        .as_ref()
+                                                        .map(|c| &c.name)
+                                                        == Some(&net.name)
+                                                    {
+                                                        Some(LinkKind::Wifi)
+                                                    } else {
+                                                        None
+                                                    }
+                                                }
+                                                _ => None,
+                                            };
+
+                                            match kind {
+                                                Some(kind) => {
+                                                    let client = app.client.clone();
+                                                    let sender_clone = sender.clone();
+                                                    tokio::spawn(async move {
+                                                        let (msg, level) = match client
+                                                            .prefer_internet(kind)
+                                                            .await
+                                                        {
+                                                            Ok(()) => (
+                                                                format!("Internet now over {kind}"),
+                                                                notification::NotificationLevel::Info,
+                                                            ),
+                                                            Err(e) => (
+                                                                e.to_string(),
+                                                                notification::NotificationLevel::Error,
+                                                            ),
+                                                        };
+                                                        let _ = Notification::send(
+                                                            msg,
+                                                            level,
+                                                            &sender_clone,
+                                                        );
+                                                    });
+                                                }
+                                                None => {
+                                                    Notification::send(
+                                                        "Connect to this link first to make it the internet path".to_string(),
+                                                        notification::NotificationLevel::Warning,
+                                                        &sender,
+                                                    )?;
+                                                }
                                             }
                                         }
 

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -7,7 +7,9 @@ pub mod speed_test;
 
 use std::sync::Arc;
 
-use crate::nm::{AccessPointInfo, ConnectionInfo, DiagnosticInfo, NMClient, StationState};
+use crate::nm::{
+    AccessPointInfo, ConnectionInfo, DiagnosticInfo, LinkKind, NMClient, StationState,
+};
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Flex, Layout},
@@ -445,6 +447,7 @@ impl Station {
         device: &Device,
         config: Arc<Config>,
         view: &AdapterView,
+        primary_kind: Option<LinkKind>,
     ) {
         let (known_networks_block, new_networks_block, device_block, help_block) = {
             let chunks = Layout::default()
@@ -567,16 +570,21 @@ impl Station {
                 if let Some(connected_net) = &self.connected_network
                     && connected_net.name == net.name
                 {
-                    let row = vec![
+                    let row = Row::new(vec![
                         Line::from("󰖩 ").centered(),
                         Line::from(known.name.clone()).centered(),
                         Line::from(known.network_type.to_string()).centered(),
                         Line::from(if known.is_hidden { "Yes" } else { "No" }).centered(),
                         Line::from(if known.is_autoconnect { "Yes" } else { "No" }).centered(),
                         Line::from(signal_str).centered(),
-                    ];
+                    ]);
 
-                    return Row::new(row);
+                    // Highlight the link NM is actually routing internet over.
+                    return if primary_kind == Some(LinkKind::Wifi) {
+                        row.green().bold()
+                    } else {
+                        row
+                    };
                 }
 
                 let row = vec![
@@ -602,6 +610,12 @@ impl Station {
                 Line::from("-").centered(),
                 Line::from("-").centered(),
             ]);
+            // Highlight Ethernet when it's the link carrying internet traffic.
+            let ethernet_row = if primary_kind == Some(LinkKind::Ethernet) {
+                ethernet_row.green().bold()
+            } else {
+                ethernet_row
+            };
             rows.insert(0, ethernet_row);
         }
 
@@ -872,6 +886,9 @@ impl Station {
                             Span::from(" | "),
                             Span::from(config.station.known_network.speed_test.to_string()).bold(),
                             Span::from(" Speed"),
+                            Span::from(" | "),
+                            Span::from(config.station.known_network.prefer.to_string()).bold(),
+                            Span::from(" Internet"),
                         ]),
                     ]
                 } else {
@@ -903,6 +920,9 @@ impl Station {
                         Span::from(" | "),
                         Span::from(config.station.known_network.speed_test.to_string()).bold(),
                         Span::from(" Speed"),
+                        Span::from(" | "),
+                        Span::from(config.station.known_network.prefer.to_string()).bold(),
+                        Span::from(" Internet"),
                         Span::from(" | "),
                         Span::from("ctrl+r").bold(),
                         Span::from(" Switch Mode"),

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -8,7 +8,7 @@ pub mod speed_test;
 use std::sync::Arc;
 
 use crate::nm::{
-    AccessPointInfo, ConnectionInfo, DiagnosticInfo, LinkKind, NMClient, StationState,
+    AccessPointInfo, ConnectionInfo, DiagnosticInfo, LinkKind, NMClient, PrimaryLink, StationState,
 };
 use ratatui::{
     Frame,
@@ -44,6 +44,19 @@ fn inactive_station_row<'a>(name: &str) -> Row<'a> {
         Line::from("-").centered(),
         Line::from("").centered(),
     ])
+}
+
+/// Caption for the Known Networks box naming the link that currently carries
+/// internet traffic. `None` when the route is something not shown in this list
+/// (e.g. a VPN, which the top-right badge already reports).
+fn internet_caption(primary: Option<&PrimaryLink>) -> Option<String> {
+    let primary = primary?;
+    let label = match primary.kind {
+        LinkKind::Wifi => format!("WiFi · {}", primary.id),
+        LinkKind::Ethernet => "Ethernet".to_string(),
+        LinkKind::Other => return None,
+    };
+    Some(format!(" 󰖟 Internet: {label} "))
 }
 
 /// Result of resolving the selected known networks table index,
@@ -447,8 +460,10 @@ impl Station {
         device: &Device,
         config: Arc<Config>,
         view: &AdapterView,
-        primary_kind: Option<LinkKind>,
+        primary: Option<&PrimaryLink>,
     ) {
+        // Which link kind owns the default route, used to highlight its row.
+        let primary_kind = primary.map(|p| p.kind);
         let (known_networks_block, new_networks_block, device_block, help_block) = {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -670,31 +685,38 @@ impl Station {
                 }
             })
             .block(
-                Block::default()
-                    .title(" Known Networks ")
-                    .title_style({
-                        if focused_block == FocusedBlock::KnownNetworks {
-                            Style::default().bold()
-                        } else {
-                            Style::default()
-                        }
-                    })
-                    .borders(Borders::ALL)
-                    .border_style({
-                        if focused_block == FocusedBlock::KnownNetworks {
-                            Style::default().fg(Color::Green)
-                        } else {
-                            Style::default()
-                        }
-                    })
-                    .border_type({
-                        if focused_block == FocusedBlock::KnownNetworks {
-                            BorderType::Thick
-                        } else {
-                            BorderType::default()
-                        }
-                    })
-                    .padding(Padding::horizontal(1)),
+                {
+                    let block = Block::default().title(" Known Networks ");
+                    // Spell out which link is the live internet path so the green
+                    // highlight isn't the only cue.
+                    match internet_caption(primary) {
+                        Some(caption) => block.title_bottom(Line::from(caption).green().bold()),
+                        None => block,
+                    }
+                }
+                .title_style({
+                    if focused_block == FocusedBlock::KnownNetworks {
+                        Style::default().bold()
+                    } else {
+                        Style::default()
+                    }
+                })
+                .borders(Borders::ALL)
+                .border_style({
+                    if focused_block == FocusedBlock::KnownNetworks {
+                        Style::default().fg(Color::Green)
+                    } else {
+                        Style::default()
+                    }
+                })
+                .border_type({
+                    if focused_block == FocusedBlock::KnownNetworks {
+                        BorderType::Thick
+                    } else {
+                        BorderType::default()
+                    }
+                })
+                .padding(Padding::horizontal(1)),
             )
             .column_spacing(1)
             .flex(Flex::SpaceAround)

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -16,6 +16,14 @@ pub use types::*;
 const NM_BUS_NAME: &str = "org.freedesktop.NetworkManager";
 const NM_PATH: &str = "/org/freedesktop/NetworkManager";
 
+/// An activated physical (WiFi/Ethernet) connection paired with its device,
+/// used when reshuffling the default route between links.
+struct PhysicalLink {
+    kind: LinkKind,
+    connection_path: String,
+    device_path: String,
+}
+
 /// Reads a string field out of one NetworkManager settings section, returning
 /// `None` if the key is absent or not string-convertible.
 fn setting_str(section: &HashMap<String, OwnedValue>, key: &str) -> Option<String> {
@@ -1050,6 +1058,144 @@ impl NMClient {
         }
 
         Ok(None)
+    }
+
+    /// The connection NetworkManager is currently using as the default route —
+    /// the link that actually carries internet traffic. `None` when NM reports
+    /// no primary connection (e.g. nothing is online).
+    pub async fn primary_link(&self) -> Result<Option<PrimaryLink>> {
+        let proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            NM_PATH,
+            "org.freedesktop.NetworkManager",
+        )
+        .await?;
+
+        let path: OwnedObjectPath = proxy.get_property("PrimaryConnection").await?;
+        if path.as_str() == "/" {
+            return Ok(None);
+        }
+
+        let info = self.get_active_connection_info(path.as_str()).await?;
+        let nm_type: String = proxy
+            .get_property("PrimaryConnectionType")
+            .await
+            .unwrap_or_default();
+
+        Ok(Some(PrimaryLink {
+            id: info.id,
+            kind: LinkKind::from_nm_type(&nm_type),
+        }))
+    }
+
+    /// Activated WiFi / Ethernet connections paired with their device, used to
+    /// reason about and reshuffle the default route. VPNs, bridges and other
+    /// virtual links are skipped.
+    async fn active_physical_links(&self) -> Result<Vec<PhysicalLink>> {
+        let mut links = Vec::new();
+
+        for conn_path in self.get_active_connections().await? {
+            let Ok(info) = self.get_active_connection_info(conn_path.as_str()).await else {
+                continue;
+            };
+            if info.state != ActiveConnectionState::Activated {
+                continue;
+            }
+
+            let Ok(settings) = self.get_connection_settings(&info.connection_path).await else {
+                continue;
+            };
+            let nm_type = settings
+                .get("connection")
+                .and_then(|c| c.get("type"))
+                .and_then(|t| t.try_clone().ok())
+                .and_then(|t| String::try_from(t).ok())
+                .unwrap_or_default();
+            let kind = LinkKind::from_nm_type(&nm_type);
+            if kind == LinkKind::Other {
+                continue;
+            }
+
+            let Some(device_path) = info.devices.first().cloned() else {
+                continue;
+            };
+
+            links.push(PhysicalLink {
+                kind,
+                connection_path: info.connection_path,
+                device_path,
+            });
+        }
+
+        Ok(links)
+    }
+
+    /// Sets the IPv4 and IPv6 route metric on a saved connection. Lower wins, so
+    /// this is how the default route is steered between links. Existing settings
+    /// are preserved; only the metric keys are touched.
+    async fn set_route_metric(&self, connection_path: &str, metric: i64) -> Result<()> {
+        let proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            connection_path,
+            "org.freedesktop.NetworkManager.Settings.Connection",
+        )
+        .await?;
+
+        let mut settings: HashMap<String, HashMap<String, OwnedValue>> =
+            proxy.call("GetSettings", &()).await?;
+
+        for family in ["ipv4", "ipv6"] {
+            settings
+                .entry(family.to_string())
+                .or_default()
+                .insert("route-metric".to_string(), OwnedValue::from(metric));
+        }
+
+        let _: () = proxy.call("Update", &(settings,)).await?;
+        Ok(())
+    }
+
+    /// Make the active link of `kind` the default route (the internet path)
+    /// while leaving the other links up. Gives the chosen link a low route
+    /// metric and the others a high one, then reactivates them so NM applies the
+    /// change — which briefly blips each affected link.
+    pub async fn prefer_internet(&self, kind: LinkKind) -> Result<()> {
+        const PREFERRED_METRIC: i64 = 50;
+        const DEPRIORITIZED_METRIC: i64 = 600;
+
+        let links = self.active_physical_links().await?;
+        if !links.iter().any(|l| l.kind == kind) {
+            anyhow::bail!("No active {kind} link to switch to");
+        }
+        if links.len() < 2 {
+            anyhow::bail!("{kind} is already the only internet path");
+        }
+
+        for link in &links {
+            let metric = if link.kind == kind {
+                PREFERRED_METRIC
+            } else {
+                DEPRIORITIZED_METRIC
+            };
+            self.set_route_metric(&link.connection_path, metric).await?;
+        }
+
+        // Reactivate the deprioritized links first, then the chosen one last so
+        // it ends up owning the default route. Other-link failures are
+        // best-effort; the chosen link must succeed.
+        for link in links.iter().filter(|l| l.kind != kind) {
+            let _ = self
+                .activate_connection(&link.connection_path, &link.device_path)
+                .await;
+        }
+        if let Some(target) = links.iter().find(|l| l.kind == kind) {
+            self.activate_connection(&target.connection_path, &target.device_path)
+                .await?;
+        }
+
+        Ok(())
     }
 
     /// Get active connection info

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -35,6 +35,45 @@ pub struct EthernetInfo {
     pub ipv4: Option<String>,
 }
 
+/// Kind of physical link, derived from a NetworkManager connection type. Used
+/// to flag and switch which link carries the default route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkKind {
+    Wifi,
+    Ethernet,
+    Other,
+}
+
+impl LinkKind {
+    /// Maps a NetworkManager connection `type` string to a link kind.
+    pub fn from_nm_type(nm_type: &str) -> Self {
+        match nm_type {
+            "802-11-wireless" => LinkKind::Wifi,
+            "802-3-ethernet" => LinkKind::Ethernet,
+            _ => LinkKind::Other,
+        }
+    }
+}
+
+impl fmt::Display for LinkKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LinkKind::Wifi => write!(f, "WiFi"),
+            LinkKind::Ethernet => write!(f, "Ethernet"),
+            LinkKind::Other => write!(f, "connection"),
+        }
+    }
+}
+
+/// The connection NetworkManager is using as the default route — i.e. the link
+/// that actually carries internet traffic. Resolved from the Manager's
+/// `PrimaryConnection`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrimaryLink {
+    pub id: String,
+    pub kind: LinkKind,
+}
+
 /// Active IPv4 configuration pulled from an NM device's `Ip4Config` object.
 #[derive(Debug, Clone, Default)]
 pub struct Ip4Info {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             let device = app.device.clone();
             match app.device.mode {
                 Mode::Station => {
-                    let primary_kind = app.primary_link.as_ref().map(|p| p.kind);
+                    let primary = app.primary_link.clone();
                     if let Some(station) = &mut app.device.station {
                         station.render(
                             frame,
@@ -41,7 +41,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                             &device,
                             app.config.clone(),
                             &view,
-                            primary_kind,
+                            primary.as_ref(),
                         );
                     }
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,6 +33,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
             let device = app.device.clone();
             match app.device.mode {
                 Mode::Station => {
+                    let primary_kind = app.primary_link.as_ref().map(|p| p.kind);
                     if let Some(station) = &mut app.device.station {
                         station.render(
                             frame,
@@ -40,6 +41,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                             &device,
                             app.config.clone(),
                             &view,
+                            primary_kind,
                         );
                     }
                 }


### PR DESCRIPTION
Stacked on #80. When WiFi and Ethernet are both up, highlights the link carrying internet (NM's default route) in green, and adds `u` to switch the route to the selected link while keeping both up.