### PR TITLE
feat: device IP, New Networks SSID filter, SSID column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Show which link carries internet traffic: when WiFi and Ethernet are both up,
-  the active default-route link is highlighted in green
+  the active default-route link is highlighted in green, with a box-footer
+  caption naming it
 - Switch the internet path with `u` — make the Ethernet row or connected WiFi
   the default route while keeping the other link up
+- Filter the New Networks scan list by SSID with `/`
+- Device box footer shows the active adapter's LAN IP (handy for SSH)
 
 ## [0.1.8] - 2026-06-16
 

--- a/Readme.md
+++ b/Readme.md
@@ -72,7 +72,9 @@ Needs NetworkManager running. [Nerd Fonts](https://www.nerdfonts.com/) optional,
 | QR share | `p` |
 | Speed test (needs `speedtest-cli`) | `Shift+S` |
 
-When both WiFi and Ethernet are up, the link NetworkManager is actually routing internet over is highlighted in green. Press `u` on the Ethernet row or the connected WiFi to switch the default route to it (the other link stays up).
+When both WiFi and Ethernet are up, the link NetworkManager is actually routing internet over is highlighted in green, and the box footer spells it out (`󰖟 Internet: WiFi · <ssid>`). Press `u` on the Ethernet row or the connected WiFi to switch the default route to it (the other link stays up).
+
+The Device box footer shows the active adapter's LAN IP (e.g. `󰩟 wlan0 · 192.168.1.20`) so you can SSH in without running `ip addr`.
 
 ### New networks
 
@@ -80,7 +82,10 @@ When both WiFi and Ethernet are up, the link NetworkManager is actually routing 
 |---|---|
 | Connect / disconnect | `Space` or `Enter` |
 | Connect to hidden | `h` |
+| Filter by name | `/` |
 | Show all | `a` |
+
+Press `/` to filter the scan list by SSID as you type; `Enter` keeps the filter, `Esc` clears it.
 
 ### VPN connections (open with `v`)
 
@@ -146,6 +151,7 @@ prefer = "u"
 [station.new_network]
 show_all = "a"
 connect_hidden = "h"
+filter = "/"
 
 [access_point]
 start = "n"

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,8 @@ pub struct NewNetwork {
     pub show_all: char,
     #[serde(default = "default_connect_hidden")]
     pub connect_hidden: char,
+    #[serde(default = "default_new_network_filter")]
+    pub filter: char,
 }
 
 impl Default for NewNetwork {
@@ -153,12 +155,17 @@ impl Default for NewNetwork {
         Self {
             show_all: 'a',
             connect_hidden: 'h',
+            filter: '/',
         }
     }
 }
 
 fn default_connect_hidden() -> char {
     'h'
+}
+
+fn default_new_network_filter() -> char {
+    '/'
 }
 
 // Access Point

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -735,16 +735,41 @@ pub async fn handle_key_events(
 
                         // Typing an SSID filter captures keys before the global
                         // quit/scan/Tab shortcuts, so 'q', 's', etc. land in the
-                        // query instead of triggering actions.
+                        // query instead of triggering actions. Control-modified
+                        // chords (Ctrl+C, Ctrl+R, …) deliberately fall through
+                        // so universal escape hatches still work mid-typing.
                         if app.focused_block == FocusedBlock::NewNetworks && station.filter_input {
-                            match key_event.code {
-                                KeyCode::Esc => station.clear_new_filter(),
-                                KeyCode::Enter => station.commit_new_filter(),
-                                KeyCode::Backspace => station.pop_new_filter(),
-                                KeyCode::Char(c) => station.push_new_filter(c),
-                                _ => {}
+                            let is_chord = key_event.modifiers.intersects(
+                                KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER,
+                            );
+                            let consumed = match key_event.code {
+                                KeyCode::Esc => {
+                                    station.clear_new_filter();
+                                    true
+                                }
+                                KeyCode::Enter => {
+                                    station.commit_new_filter();
+                                    true
+                                }
+                                KeyCode::Backspace => {
+                                    station.pop_new_filter();
+                                    true
+                                }
+                                KeyCode::Char(c) if !is_chord => {
+                                    station.push_new_filter(c);
+                                    true
+                                }
+                                // Control chord on a Char: don't push into the
+                                // query — let it through to the global handler.
+                                KeyCode::Char(_) => false,
+                                // Anything else (Tab, arrows, …) stays trapped
+                                // by the modal input so focus and selection
+                                // don't shift mid-edit.
+                                _ => true,
+                            };
+                            if consumed {
+                                return Ok(());
                             }
-                            return Ok(());
                         }
 
                         match key_event.code {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -720,6 +720,19 @@ pub async fn handle_key_events(
                         }
                     }
                     _ => {
+                        // Esc clears an applied SSID filter even after Enter
+                        // commits it (filter_input is false but the query is
+                        // still in effect). Without this, Esc would fall
+                        // through to global handling — possibly quitting.
+                        if app.focused_block == FocusedBlock::NewNetworks
+                            && key_event.code == KeyCode::Esc
+                            && !station.filter_input
+                            && station.new_filter_active()
+                        {
+                            station.clear_new_filter();
+                            return Ok(());
+                        }
+
                         // Typing an SSID filter captures keys before the global
                         // quit/scan/Tab shortcuts, so 'q', 's', etc. land in the
                         // query instead of triggering actions.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,9 +6,9 @@ use crate::config::Config;
 use crate::device::Device;
 use crate::event::Event;
 use crate::mode::ap::APFocusedSection;
-use crate::mode::station::KnownNetworkSelection;
 use crate::mode::station::share::Share;
 use crate::mode::station::speed_test::SpeedTest;
+use crate::mode::station::{KnownNetworkSelection, NewNetworkSelection};
 use crate::nm::{LinkKind, Mode, SecurityType};
 use crate::notification::{self, Notification};
 
@@ -20,9 +20,9 @@ pub async fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) -> Re
     if let Some(station) = &mut app.device.station {
         match app.focused_block {
             FocusedBlock::NewNetworks => {
-                if let Some(net_index) = station.new_networks_state.selected() {
-                    if net_index < station.new_networks.len() {
-                        let (net, _) = station.new_networks[net_index].clone();
+                match station.resolve_new_selection() {
+                    Some(NewNetworkSelection::Visible(idx)) => {
+                        let (net, _) = station.new_networks[idx].clone();
 
                         // Check if it's an enterprise network
                         if net.network_type == SecurityType::Enterprise {
@@ -46,11 +46,9 @@ pub async fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) -> Re
                         tokio::spawn(async move {
                             let _ = net.connect(sender.clone(), None).await;
                         });
-                    } else {
-                        // Hidden network selected
-                        let net = station.new_hidden_networks
-                            [net_index.saturating_sub(station.new_networks.len())]
-                        .clone();
+                    }
+                    Some(NewNetworkSelection::Hidden(idx)) => {
+                        let net = station.new_hidden_networks[idx].clone();
 
                         if net.network_type == "8021x" {
                             sender.send(Event::ConfigureNewEapNetwork(net.address.clone()))?;
@@ -64,6 +62,7 @@ pub async fn toggle_connect(app: &mut App, sender: UnboundedSender<Event>) -> Re
                             &sender,
                         );
                     }
+                    None => {}
                 }
             }
             FocusedBlock::KnownNetworks => {
@@ -721,6 +720,20 @@ pub async fn handle_key_events(
                         }
                     }
                     _ => {
+                        // Typing an SSID filter captures keys before the global
+                        // quit/scan/Tab shortcuts, so 'q', 's', etc. land in the
+                        // query instead of triggering actions.
+                        if app.focused_block == FocusedBlock::NewNetworks && station.filter_input {
+                            match key_event.code {
+                                KeyCode::Esc => station.clear_new_filter(),
+                                KeyCode::Enter => station.commit_new_filter(),
+                                KeyCode::Backspace => station.pop_new_filter(),
+                                KeyCode::Char(c) => station.push_new_filter(c),
+                                _ => {}
+                            }
+                            return Ok(());
+                        }
+
                         match key_event.code {
                             KeyCode::Char('q') => {
                                 app.quit();
@@ -1010,6 +1023,10 @@ pub async fn handle_key_events(
                                     }
                                 }
                                 FocusedBlock::NewNetworks => match key_event.code {
+                                    // Start filtering the scan list by SSID
+                                    KeyCode::Char(c) if c == config.station.new_network.filter => {
+                                        station.start_new_filter();
+                                    }
                                     // Show / Hide unavailable networks
                                     KeyCode::Char(c)
                                         if c == config.station.new_network.show_all =>
@@ -1026,34 +1043,25 @@ pub async fn handle_key_events(
                                     KeyCode::Enter | KeyCode::Char(' ') => {
                                         toggle_connect(app, sender).await?
                                     }
-                                    KeyCode::Char('j') | KeyCode::Down
-                                        if !station.new_networks.is_empty() =>
-                                    {
-                                        let i = match station.new_networks_state.selected() {
-                                            Some(i) => {
-                                                let limit = if station.show_hidden_networks {
-                                                    station.new_networks.len()
-                                                        + station.new_hidden_networks.len()
-                                                        - 1
-                                                } else {
-                                                    station.new_networks.len() - 1
-                                                };
-                                                if i < limit { i + 1 } else { i }
-                                            }
-                                            None => 0,
-                                        };
-
-                                        station.new_networks_state.select(Some(i));
+                                    KeyCode::Char('j') | KeyCode::Down => {
+                                        let total = station.new_networks_total_rows();
+                                        if total > 0 {
+                                            let i = match station.new_networks_state.selected() {
+                                                Some(i) => (i + 1).min(total - 1),
+                                                None => 0,
+                                            };
+                                            station.new_networks_state.select(Some(i));
+                                        }
                                     }
-                                    KeyCode::Char('k') | KeyCode::Up
-                                        if !station.new_networks.is_empty() =>
-                                    {
-                                        let i = match station.new_networks_state.selected() {
-                                            Some(i) => i.saturating_sub(1),
-                                            None => 0,
-                                        };
-
-                                        station.new_networks_state.select(Some(i));
+                                    KeyCode::Char('k') | KeyCode::Up => {
+                                        let total = station.new_networks_total_rows();
+                                        if total > 0 {
+                                            let i = match station.new_networks_state.selected() {
+                                                Some(i) => i.saturating_sub(1),
+                                                None => 0,
+                                            };
+                                            station.new_networks_state.select(Some(i));
+                                        }
                                     }
                                     _ => {}
                                 },

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -46,6 +46,21 @@ fn inactive_station_row<'a>(name: &str) -> Row<'a> {
     ])
 }
 
+/// One "key Label | " trio for a help line. Callers chain `extend(hint(…))`
+/// and `pop()` the final separator. Centralizing the format keeps every help
+/// row syntactically identical, so adding a shortcut is a one-line change
+/// instead of three coordinated `Span::from` calls.
+fn hint(
+    key: impl Into<std::borrow::Cow<'static, str>>,
+    label: impl Into<std::borrow::Cow<'static, str>>,
+) -> [Span<'static>; 3] {
+    [
+        Span::from(key.into()).bold(),
+        Span::from(label.into()),
+        Span::from(" | "),
+    ]
+}
+
 /// Caption for the Known Networks box naming the link that currently carries
 /// internet traffic. `None` when the route is something not shown in this list
 /// (e.g. a VPN, which the top-right badge already reports).
@@ -113,6 +128,10 @@ pub struct Station {
     pub filter_query: String,
     /// Whether the New Networks filter is currently being typed into.
     pub filter_input: bool,
+    /// Indices into `new_networks` matching the current filter, in row order.
+    /// Cached so each render pass doesn't re-walk + re-lowercase every SSID;
+    /// recomputed only when `new_networks` is replaced or the filter mutates.
+    visible_new: Vec<usize>,
 }
 
 impl Station {
@@ -151,6 +170,9 @@ impl Station {
 
         let ipv4 = Self::fetch_device_ipv4(&client, &device_path).await;
 
+        // No filter at startup, so every visible AP is in the visible set.
+        let visible_new = (0..new_networks.len()).collect();
+
         Ok(Self {
             client,
             device_path,
@@ -172,6 +194,7 @@ impl Station {
             ipv4,
             filter_query: String::new(),
             filter_input: false,
+            visible_new,
         })
     }
 
@@ -213,6 +236,9 @@ impl Station {
             |s| &mut s.new_networks,
             |s| &mut s.new_networks_state,
         );
+        // `new_networks` just changed under us — rebuild the filtered view so
+        // the cursor and the rendered rows agree on what's visible.
+        self.recompute_visible_new();
         self.update_known_network_list(&known_networks);
 
         self.unavailable_known_networks =
@@ -460,24 +486,33 @@ impl Station {
     }
 
     /// True when an SSID filter is narrowing the New Networks list.
-    pub fn new_filter_active(&self) -> bool {
+    pub(crate) fn new_filter_active(&self) -> bool {
         !self.filter_query.trim().is_empty()
     }
 
-    /// Case-insensitive substring match used by the New Networks filter.
-    fn new_filter_matches(&self, name: &str) -> bool {
-        let query = self.filter_query.trim().to_lowercase();
-        query.is_empty() || name.to_lowercase().contains(&query)
+    /// Indices into `new_networks` currently visible under the filter, in
+    /// order. Reads the cache so render passes don't re-walk + re-lowercase
+    /// every SSID; the cache is refreshed by [`Self::recompute_visible_new`]
+    /// whenever the query or `new_networks` changes.
+    pub(crate) fn visible_new_indices(&self) -> &[usize] {
+        &self.visible_new
     }
 
-    /// Indices into `new_networks` currently visible under the filter, in order.
-    pub fn visible_new_indices(&self) -> Vec<usize> {
-        self.new_networks
-            .iter()
-            .enumerate()
-            .filter(|(_, (net, _))| self.new_filter_matches(&net.name))
-            .map(|(i, _)| i)
-            .collect()
+    /// Rebuilds the visible-new cache. The query is normalized once here,
+    /// not per row, so a typed-into filter doesn't pay N allocations per
+    /// render for N rows.
+    fn recompute_visible_new(&mut self) {
+        let query = self.filter_query.trim().to_lowercase();
+        self.visible_new.clear();
+        if query.is_empty() {
+            self.visible_new.extend(0..self.new_networks.len());
+            return;
+        }
+        for (idx, (net, _)) in self.new_networks.iter().enumerate() {
+            if net.name.to_lowercase().contains(&query) {
+                self.visible_new.push(idx);
+            }
+        }
     }
 
     /// Whether hidden-SSID rows are shown. They carry no SSID to match, so an
@@ -487,18 +522,18 @@ impl Station {
     }
 
     /// Total rows the New Networks table renders, for cursor clamping.
-    pub fn new_networks_total_rows(&self) -> usize {
+    pub(crate) fn new_networks_total_rows(&self) -> usize {
         let hidden = if self.hidden_rows_visible() {
             self.new_hidden_networks.len()
         } else {
             0
         };
-        self.visible_new_indices().len() + hidden
+        self.visible_new.len() + hidden
     }
 
     /// Resolves the highlighted New Networks row to real data, mapping through
     /// the filter so the cursor and the action target never diverge.
-    pub fn resolve_new_selection(&self) -> Option<NewNetworkSelection> {
+    pub(crate) fn resolve_new_selection(&self) -> Option<NewNetworkSelection> {
         let selected = self.new_networks_state.selected()?;
         let visible = self.visible_new_indices();
 
@@ -523,31 +558,35 @@ impl Station {
     }
 
     /// Begins typing an SSID filter on the New Networks list.
-    pub fn start_new_filter(&mut self) {
+    pub(crate) fn start_new_filter(&mut self) {
         self.filter_input = true;
     }
 
     /// Appends a character to the active filter and re-anchors the cursor.
-    pub fn push_new_filter(&mut self, c: char) {
+    pub(crate) fn push_new_filter(&mut self, c: char) {
         self.filter_query.push(c);
+        self.recompute_visible_new();
         self.reset_new_selection();
     }
 
     /// Deletes the last filter character and re-anchors the cursor.
-    pub fn pop_new_filter(&mut self) {
+    pub(crate) fn pop_new_filter(&mut self) {
         self.filter_query.pop();
+        self.recompute_visible_new();
         self.reset_new_selection();
     }
 
-    /// Stops editing but keeps the filter applied.
-    pub fn commit_new_filter(&mut self) {
+    /// Stops editing but keeps the filter applied. The visible set is unchanged
+    /// (query didn't change) so no recompute is needed.
+    pub(crate) fn commit_new_filter(&mut self) {
         self.filter_input = false;
     }
 
     /// Clears the filter entirely and exits editing.
-    pub fn clear_new_filter(&mut self) {
+    pub(crate) fn clear_new_filter(&mut self) {
         self.filter_query.clear();
         self.filter_input = false;
+        self.recompute_visible_new();
         self.reset_new_selection();
     }
 
@@ -894,8 +933,8 @@ impl Station {
         //
         let mut rows: Vec<Row> = self
             .visible_new_indices()
-            .into_iter()
-            .map(|idx| {
+            .iter()
+            .map(|&idx| {
                 let (net, signal) = &self.new_networks[idx];
                 let signal_percent = (*signal / 100).clamp(0, 100);
                 Row::new(vec![
@@ -1037,43 +1076,22 @@ impl Station {
                 vec![Line::from(spans)]
             }
             FocusedBlock::KnownNetworks => {
-                let single_line = Line::from(vec![
-                    Span::from("k,").bold(),
-                    Span::from("  Up"),
-                    Span::from(" | "),
-                    Span::from("j,").bold(),
-                    Span::from("  Down"),
-                    Span::from(" | "),
-                    Span::from("󱁐  or ↵ ").bold(),
-                    Span::from(" Dis/connect"),
-                    Span::from(" | "),
-                    Span::from(config.station.known_network.show_all.to_string()).bold(),
-                    Span::from(" Show All"),
-                    Span::from(" | "),
-                    Span::from(config.station.known_network.remove.to_string()).bold(),
-                    Span::from(" Remove"),
-                    Span::from(" | "),
-                    Span::from(config.station.known_network.toggle_autoconnect.to_string()).bold(),
-                    Span::from(" Autoconnect"),
-                    Span::from(" | "),
-                    Span::from(config.station.start_scanning.to_string()).bold(),
-                    Span::from(" Scan"),
-                    Span::from(" | "),
-                    Span::from(config.station.known_network.share.to_string()).bold(),
-                    Span::from(" Share"),
-                    Span::from(" | "),
-                    Span::from(config.station.known_network.speed_test.to_string()).bold(),
-                    Span::from(" Speed"),
-                    Span::from(" | "),
-                    Span::from(config.station.known_network.prefer.to_string()).bold(),
-                    Span::from(" Internet"),
-                    Span::from(" | "),
-                    Span::from("ctrl+r").bold(),
-                    Span::from(" Switch Mode"),
-                    Span::from(" | "),
-                    Span::from("⇄").bold(),
-                    Span::from(" Nav"),
-                ]);
+                let kn = &config.station.known_network;
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                spans.extend(hint("k,", "  Up"));
+                spans.extend(hint("j,", "  Down"));
+                spans.extend(hint("󱁐  or ↵ ", " Dis/connect"));
+                spans.extend(hint(kn.show_all.to_string(), " Show All"));
+                spans.extend(hint(kn.remove.to_string(), " Remove"));
+                spans.extend(hint(kn.toggle_autoconnect.to_string(), " Autoconnect"));
+                spans.extend(hint(config.station.start_scanning.to_string(), " Scan"));
+                spans.extend(hint(kn.share.to_string(), " Share"));
+                spans.extend(hint(kn.speed_test.to_string(), " Speed"));
+                spans.extend(hint(kn.prefer.to_string(), " Internet"));
+                spans.extend(hint("ctrl+r", " Switch Mode"));
+                spans.extend(hint("⇄", " Nav"));
+                spans.pop(); // trailing " | " from the last hint
+                let single_line = Line::from(spans);
                 // The VPN hint is appended to the last line below, so account
                 // for it when deciding if the one-line layout fits.
                 let vpn_suffix_width =
@@ -1084,78 +1102,44 @@ impl Station {
                 if one_line_fits {
                     vec![single_line]
                 } else {
-                    vec![
-                        Line::from(vec![
-                            Span::from("󱁐  or ↵ ").bold(),
-                            Span::from(" Dis/connect"),
-                            Span::from(" | "),
-                            Span::from(config.station.known_network.show_all.to_string()).bold(),
-                            Span::from(" Show All"),
-                            Span::from(" | "),
-                            Span::from(config.station.known_network.remove.to_string()).bold(),
-                            Span::from(" Remove"),
-                            Span::from(" | "),
-                            Span::from(config.station.known_network.share.to_string()).bold(),
-                            Span::from(" Share"),
-                            Span::from(" | "),
-                            Span::from(config.station.start_scanning.to_string()).bold(),
-                            Span::from(" Scan"),
-                        ]),
-                        Line::from(vec![
-                            Span::from("k,").bold(),
-                            Span::from("  Up"),
-                            Span::from(" | "),
-                            Span::from("j,").bold(),
-                            Span::from("  Down"),
-                            Span::from(" | "),
-                            Span::from("⇄").bold(),
-                            Span::from(" Nav"),
-                            Span::from(" | "),
-                            Span::from("ctrl+r").bold(),
-                            Span::from(" Switch Mode"),
-                            Span::from(" | "),
-                            Span::from(config.station.known_network.toggle_autoconnect.to_string())
-                                .bold(),
-                            Span::from(" Autoconnect"),
-                            Span::from(" | "),
-                            Span::from(config.station.known_network.speed_test.to_string()).bold(),
-                            Span::from(" Speed"),
-                            Span::from(" | "),
-                            Span::from(config.station.known_network.prefer.to_string()).bold(),
-                            Span::from(" Internet"),
-                        ]),
-                    ]
+                    // Two-row fallback: first row = action keys, second =
+                    // navigation/mode/internet path. Split chosen so each row
+                    // groups related shortcuts.
+                    let mut top: Vec<Span<'static>> = Vec::new();
+                    top.extend(hint("󱁐  or ↵ ", " Dis/connect"));
+                    top.extend(hint(kn.show_all.to_string(), " Show All"));
+                    top.extend(hint(kn.remove.to_string(), " Remove"));
+                    top.extend(hint(kn.share.to_string(), " Share"));
+                    top.extend(hint(config.station.start_scanning.to_string(), " Scan"));
+                    top.pop();
+
+                    let mut bottom: Vec<Span<'static>> = Vec::new();
+                    bottom.extend(hint("k,", "  Up"));
+                    bottom.extend(hint("j,", "  Down"));
+                    bottom.extend(hint("⇄", " Nav"));
+                    bottom.extend(hint("ctrl+r", " Switch Mode"));
+                    bottom.extend(hint(kn.toggle_autoconnect.to_string(), " Autoconnect"));
+                    bottom.extend(hint(kn.speed_test.to_string(), " Speed"));
+                    bottom.extend(hint(kn.prefer.to_string(), " Internet"));
+                    bottom.pop();
+
+                    vec![Line::from(top), Line::from(bottom)]
                 }
             }
             FocusedBlock::NewNetworks => {
-                let single_line = Line::from(vec![
-                    Span::from("k,").bold(),
-                    Span::from("  Up"),
-                    Span::from(" | "),
-                    Span::from("j,").bold(),
-                    Span::from("  Down"),
-                    Span::from(" | "),
-                    Span::from("󱁐  or ↵ ").bold(),
-                    Span::from(" Connect"),
-                    Span::from(" | "),
-                    Span::from(config.station.new_network.connect_hidden.to_string()).bold(),
-                    Span::from(" Hidden"),
-                    Span::from(" | "),
-                    Span::from(config.station.new_network.show_all.to_string()).bold(),
-                    Span::from(" Show All"),
-                    Span::from(" | "),
-                    Span::from(config.station.new_network.filter.to_string()).bold(),
-                    Span::from(" Filter"),
-                    Span::from(" | "),
-                    Span::from(config.station.start_scanning.to_string()).bold(),
-                    Span::from(" Scan"),
-                    Span::from(" | "),
-                    Span::from("ctrl+r").bold(),
-                    Span::from(" Switch Mode"),
-                    Span::from(" | "),
-                    Span::from("⇄").bold(),
-                    Span::from(" Nav"),
-                ]);
+                let nn = &config.station.new_network;
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                spans.extend(hint("k,", "  Up"));
+                spans.extend(hint("j,", "  Down"));
+                spans.extend(hint("󱁐  or ↵ ", " Connect"));
+                spans.extend(hint(nn.connect_hidden.to_string(), " Hidden"));
+                spans.extend(hint(nn.show_all.to_string(), " Show All"));
+                spans.extend(hint(nn.filter.to_string(), " Filter"));
+                spans.extend(hint(config.station.start_scanning.to_string(), " Scan"));
+                spans.extend(hint("ctrl+r", " Switch Mode"));
+                spans.extend(hint("⇄", " Nav"));
+                spans.pop();
+                let single_line = Line::from(spans);
                 let vpn_suffix_width =
                     Line::from(crate::device::vpn_hint_spans(config.vpn)).width() as u16;
                 let one_line_fits =
@@ -1164,35 +1148,21 @@ impl Station {
                 if one_line_fits {
                     vec![single_line]
                 } else {
-                    vec![
-                        Line::from(vec![
-                            Span::from("󱁐  or ↵ ").bold(),
-                            Span::from(" Connect"),
-                            Span::from(" | "),
-                            Span::from(config.station.new_network.connect_hidden.to_string())
-                                .bold(),
-                            Span::from(" Hidden"),
-                            Span::from(" | "),
-                            Span::from(config.station.new_network.filter.to_string()).bold(),
-                            Span::from(" Filter"),
-                            Span::from(" | "),
-                            Span::from(config.station.start_scanning.to_string()).bold(),
-                            Span::from(" Scan"),
-                        ]),
-                        Line::from(vec![
-                            Span::from("k,").bold(),
-                            Span::from("  Up"),
-                            Span::from(" | "),
-                            Span::from("j,").bold(),
-                            Span::from("  Down"),
-                            Span::from(" | "),
-                            Span::from("ctrl+r").bold(),
-                            Span::from(" Switch Mode"),
-                            Span::from(" | "),
-                            Span::from("⇄").bold(),
-                            Span::from(" Nav"),
-                        ]),
-                    ]
+                    let mut top: Vec<Span<'static>> = Vec::new();
+                    top.extend(hint("󱁐  or ↵ ", " Connect"));
+                    top.extend(hint(nn.connect_hidden.to_string(), " Hidden"));
+                    top.extend(hint(nn.filter.to_string(), " Filter"));
+                    top.extend(hint(config.station.start_scanning.to_string(), " Scan"));
+                    top.pop();
+
+                    let mut bottom: Vec<Span<'static>> = Vec::new();
+                    bottom.extend(hint("k,", "  Up"));
+                    bottom.extend(hint("j,", "  Down"));
+                    bottom.extend(hint("ctrl+r", " Switch Mode"));
+                    bottom.extend(hint("⇄", " Nav"));
+                    bottom.pop();
+
+                    vec![Line::from(top), Line::from(bottom)]
                 }
             }
             FocusedBlock::AdapterInfos => {
@@ -1235,16 +1205,12 @@ impl Station {
         // `v` lands in the query, not the modal.
         let typing_filter = focused_block == FocusedBlock::NewNetworks && self.filter_input;
         if typing_filter {
-            help_message = vec![Line::from(vec![
-                Span::from(" ↵ ").bold(),
-                Span::from(" Apply"),
-                Span::from(" | "),
-                Span::from("󱊷 ").bold(),
-                Span::from(" Cancel"),
-                Span::from(" | "),
-                Span::from("⌫ ").bold(),
-                Span::from(" Delete"),
-            ])];
+            let mut spans: Vec<Span<'static>> = Vec::new();
+            spans.extend(hint(" ↵ ", " Apply"));
+            spans.extend(hint("󱊷 ", " Cancel"));
+            spans.extend(hint("⌫ ", " Delete"));
+            spans.pop();
+            help_message = vec![Line::from(spans)];
         }
 
         // Advertise the global VPN shortcut from every list view by appending

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -70,6 +70,15 @@ pub enum KnownNetworkSelection {
     Unavailable(usize),
 }
 
+/// Result of resolving the selected New Networks table row to real data,
+/// accounting for the SSID filter and the trailing hidden-networks rows.
+pub enum NewNetworkSelection {
+    /// A visible scanned network at the given `new_networks` index
+    Visible(usize),
+    /// A hidden network at the given `new_hidden_networks` index
+    Hidden(usize),
+}
+
 /// Hidden network representation for NetworkManager
 #[derive(Debug, Clone)]
 pub struct HiddenNetwork {
@@ -97,6 +106,13 @@ pub struct Station {
     pub show_hidden_networks: bool,
     pub share: Option<Share>,
     pub speed_test: Option<SpeedTest>,
+    /// Primary IPv4 of the active adapter, cached for the Device-box caption so
+    /// the LAN address (handy for SSH) is visible without leaving the TUI.
+    pub ipv4: Option<String>,
+    /// Live SSID filter for the New Networks list. Empty = inactive.
+    pub filter_query: String,
+    /// Whether the New Networks filter is currently being typed into.
+    pub filter_input: bool,
 }
 
 impl Station {
@@ -133,6 +149,8 @@ impl Station {
         let diagnostic =
             Self::fetch_diagnostic(&client, &device_path, connected_network.is_some()).await?;
 
+        let ipv4 = Self::fetch_device_ipv4(&client, &device_path).await;
+
         Ok(Self {
             client,
             device_path,
@@ -151,7 +169,21 @@ impl Station {
             show_hidden_networks: false,
             share: None,
             speed_test: None,
+            ipv4,
+            filter_query: String::new(),
+            filter_input: false,
         })
+    }
+
+    /// Reads the active adapter's primary IPv4, if any. Best-effort: a missing
+    /// or unreadable address just yields `None`.
+    async fn fetch_device_ipv4(client: &Arc<NMClient>, device_path: &str) -> Option<String> {
+        client
+            .get_ip4_info(device_path)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|ip| ip.addresses.into_iter().next().map(|(addr, _)| addr))
     }
 
     pub async fn refresh(&mut self) -> Result<()> {
@@ -193,6 +225,8 @@ impl Station {
             self.connected_network.is_some(),
         )
         .await?;
+
+        self.ipv4 = Self::fetch_device_ipv4(&self.client, &self.device_path).await;
 
         Ok(())
     }
@@ -425,6 +459,112 @@ impl Station {
         ethernet_offset + self.known_networks.len() + unavail
     }
 
+    /// True when an SSID filter is narrowing the New Networks list.
+    pub fn new_filter_active(&self) -> bool {
+        !self.filter_query.trim().is_empty()
+    }
+
+    /// Case-insensitive substring match used by the New Networks filter.
+    fn new_filter_matches(&self, name: &str) -> bool {
+        let query = self.filter_query.trim().to_lowercase();
+        query.is_empty() || name.to_lowercase().contains(&query)
+    }
+
+    /// Indices into `new_networks` currently visible under the filter, in order.
+    pub fn visible_new_indices(&self) -> Vec<usize> {
+        self.new_networks
+            .iter()
+            .enumerate()
+            .filter(|(_, (net, _))| self.new_filter_matches(&net.name))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Whether hidden-SSID rows are shown. They carry no SSID to match, so an
+    /// active filter suppresses them.
+    fn hidden_rows_visible(&self) -> bool {
+        self.show_hidden_networks && !self.new_filter_active()
+    }
+
+    /// Total rows the New Networks table renders, for cursor clamping.
+    pub fn new_networks_total_rows(&self) -> usize {
+        let hidden = if self.hidden_rows_visible() {
+            self.new_hidden_networks.len()
+        } else {
+            0
+        };
+        self.visible_new_indices().len() + hidden
+    }
+
+    /// Resolves the highlighted New Networks row to real data, mapping through
+    /// the filter so the cursor and the action target never diverge.
+    pub fn resolve_new_selection(&self) -> Option<NewNetworkSelection> {
+        let selected = self.new_networks_state.selected()?;
+        let visible = self.visible_new_indices();
+
+        if selected < visible.len() {
+            return Some(NewNetworkSelection::Visible(visible[selected]));
+        }
+        if !self.hidden_rows_visible() {
+            return None;
+        }
+        let hidden_index = selected - visible.len();
+        (hidden_index < self.new_hidden_networks.len())
+            .then_some(NewNetworkSelection::Hidden(hidden_index))
+    }
+
+    /// Snaps the New Networks cursor to a valid row after the filter changes.
+    fn reset_new_selection(&mut self) {
+        if self.new_networks_total_rows() == 0 {
+            self.new_networks_state.select(None);
+        } else {
+            self.new_networks_state.select(Some(0));
+        }
+    }
+
+    /// Begins typing an SSID filter on the New Networks list.
+    pub fn start_new_filter(&mut self) {
+        self.filter_input = true;
+    }
+
+    /// Appends a character to the active filter and re-anchors the cursor.
+    pub fn push_new_filter(&mut self, c: char) {
+        self.filter_query.push(c);
+        self.reset_new_selection();
+    }
+
+    /// Deletes the last filter character and re-anchors the cursor.
+    pub fn pop_new_filter(&mut self) {
+        self.filter_query.pop();
+        self.reset_new_selection();
+    }
+
+    /// Stops editing but keeps the filter applied.
+    pub fn commit_new_filter(&mut self) {
+        self.filter_input = false;
+    }
+
+    /// Clears the filter entirely and exits editing.
+    pub fn clear_new_filter(&mut self) {
+        self.filter_query.clear();
+        self.filter_input = false;
+        self.reset_new_selection();
+    }
+
+    /// Border caption for the New Networks box while a filter is being typed or
+    /// is applied; `None` otherwise. Includes the live match count.
+    fn new_filter_caption(&self) -> Option<String> {
+        if !self.filter_input && !self.new_filter_active() {
+            return None;
+        }
+        let matches = self.visible_new_indices().len();
+        if self.filter_input {
+            Some(format!(" / {}▏ ({matches}) ", self.filter_query))
+        } else {
+            Some(format!(" filter: {} ({matches}) ", self.filter_query))
+        }
+    }
+
     /// Row for the adapter currently active on this Station. Carries the full
     /// set of runtime columns (state/scanning/frequency/security) plus an
     /// optional active marker for the multi-adapter case.
@@ -531,31 +671,39 @@ impl Station {
                 }
             })
             .block(
-                Block::default()
-                    .title(" Device ")
-                    .title_style({
-                        if focused_block == FocusedBlock::Device {
-                            Style::default().bold()
-                        } else {
-                            Style::default()
-                        }
-                    })
-                    .borders(Borders::ALL)
-                    .border_style({
-                        if focused_block == FocusedBlock::Device {
-                            Style::default().fg(Color::Green)
-                        } else {
-                            Style::default()
-                        }
-                    })
-                    .border_type({
-                        if focused_block == FocusedBlock::Device {
-                            BorderType::Thick
-                        } else {
-                            BorderType::default()
-                        }
-                    })
-                    .padding(Padding::horizontal(1)),
+                {
+                    let block = Block::default().title(" Device ");
+                    // Surface the adapter's LAN IPv4 (handy for SSH) without
+                    // leaving the TUI.
+                    match self.ipv4.as_deref() {
+                        Some(ip) => block
+                            .title_bottom(Line::from(format!(" 󰩟 {} · {ip} ", device.name)).cyan()),
+                        None => block,
+                    }
+                }
+                .title_style({
+                    if focused_block == FocusedBlock::Device {
+                        Style::default().bold()
+                    } else {
+                        Style::default()
+                    }
+                })
+                .borders(Borders::ALL)
+                .border_style({
+                    if focused_block == FocusedBlock::Device {
+                        Style::default().fg(Color::Green)
+                    } else {
+                        Style::default()
+                    }
+                })
+                .border_type({
+                    if focused_block == FocusedBlock::Device {
+                        BorderType::Thick
+                    } else {
+                        BorderType::default()
+                    }
+                })
+                .padding(Padding::horizontal(1)),
             )
             .column_spacing(1)
             .flex(Flex::SpaceAround)
@@ -652,7 +800,9 @@ impl Station {
 
         let widths = [
             Constraint::Length(2),
-            Constraint::Length(25),
+            // 32 cells fits the max-length 32-byte SSID without clipping the
+            // centered name on both ends.
+            Constraint::Length(32),
             Constraint::Length(8),
             Constraint::Length(6),
             Constraint::Length(12),
@@ -736,9 +886,10 @@ impl Station {
         // New networks
         //
         let mut rows: Vec<Row> = self
-            .new_networks
-            .iter()
-            .map(|(net, signal)| {
+            .visible_new_indices()
+            .into_iter()
+            .map(|idx| {
+                let (net, signal) = &self.new_networks[idx];
                 let signal_percent = (*signal / 100).clamp(0, 100);
                 Row::new(vec![
                     Line::from(net.name.clone()).centered(),
@@ -756,7 +907,7 @@ impl Station {
             })
             .collect();
 
-        if self.show_hidden_networks {
+        if self.hidden_rows_visible() {
             self.new_hidden_networks.iter().for_each(|net| {
                 let signal_percent = (net.signal_strength / 100).clamp(0, 100);
                 rows.push(
@@ -779,7 +930,9 @@ impl Station {
         };
 
         let widths = [
-            Constraint::Length(25),
+            // 32 cells fits the max-length 32-byte SSID without clipping the
+            // centered name on both ends.
+            Constraint::Length(32),
             Constraint::Length(15),
             Constraint::Length(8),
         ];
@@ -804,31 +957,37 @@ impl Station {
                 }
             })
             .block(
-                Block::default()
-                    .title(" New Networks ")
-                    .title_style({
-                        if focused_block == FocusedBlock::NewNetworks {
-                            Style::default().bold()
-                        } else {
-                            Style::default()
-                        }
-                    })
-                    .borders(Borders::ALL)
-                    .border_style({
-                        if focused_block == FocusedBlock::NewNetworks {
-                            Style::default().fg(Color::Green)
-                        } else {
-                            Style::default()
-                        }
-                    })
-                    .border_type({
-                        if focused_block == FocusedBlock::NewNetworks {
-                            BorderType::Thick
-                        } else {
-                            BorderType::default()
-                        }
-                    })
-                    .padding(Padding::horizontal(1)),
+                {
+                    let block = Block::default().title(" New Networks ");
+                    // Show the live filter on the border while typing or applied.
+                    match self.new_filter_caption() {
+                        Some(caption) => block.title_bottom(Line::from(caption).yellow().bold()),
+                        None => block,
+                    }
+                }
+                .title_style({
+                    if focused_block == FocusedBlock::NewNetworks {
+                        Style::default().bold()
+                    } else {
+                        Style::default()
+                    }
+                })
+                .borders(Borders::ALL)
+                .border_style({
+                    if focused_block == FocusedBlock::NewNetworks {
+                        Style::default().fg(Color::Green)
+                    } else {
+                        Style::default()
+                    }
+                })
+                .border_type({
+                    if focused_block == FocusedBlock::NewNetworks {
+                        BorderType::Thick
+                    } else {
+                        BorderType::default()
+                    }
+                })
+                .padding(Padding::horizontal(1)),
             )
             .column_spacing(1)
             .flex(Flex::SpaceAround)
@@ -871,7 +1030,54 @@ impl Station {
                 vec![Line::from(spans)]
             }
             FocusedBlock::KnownNetworks => {
-                if frame.area().width <= 130 {
+                let single_line = Line::from(vec![
+                    Span::from("k,").bold(),
+                    Span::from("  Up"),
+                    Span::from(" | "),
+                    Span::from("j,").bold(),
+                    Span::from("  Down"),
+                    Span::from(" | "),
+                    Span::from("󱁐  or ↵ ").bold(),
+                    Span::from(" Dis/connect"),
+                    Span::from(" | "),
+                    Span::from(config.station.known_network.show_all.to_string()).bold(),
+                    Span::from(" Show All"),
+                    Span::from(" | "),
+                    Span::from(config.station.known_network.remove.to_string()).bold(),
+                    Span::from(" Remove"),
+                    Span::from(" | "),
+                    Span::from(config.station.known_network.toggle_autoconnect.to_string())
+                        .bold(),
+                    Span::from(" Autoconnect"),
+                    Span::from(" | "),
+                    Span::from(config.station.start_scanning.to_string()).bold(),
+                    Span::from(" Scan"),
+                    Span::from(" | "),
+                    Span::from(config.station.known_network.share.to_string()).bold(),
+                    Span::from(" Share"),
+                    Span::from(" | "),
+                    Span::from(config.station.known_network.speed_test.to_string()).bold(),
+                    Span::from(" Speed"),
+                    Span::from(" | "),
+                    Span::from(config.station.known_network.prefer.to_string()).bold(),
+                    Span::from(" Internet"),
+                    Span::from(" | "),
+                    Span::from("ctrl+r").bold(),
+                    Span::from(" Switch Mode"),
+                    Span::from(" | "),
+                    Span::from("⇄").bold(),
+                    Span::from(" Nav"),
+                ]);
+                // The VPN hint is appended to the last line below, so account
+                // for it when deciding if the one-line layout fits.
+                let vpn_suffix_width =
+                    Line::from(crate::device::vpn_hint_spans(config.vpn)).width() as u16;
+                let one_line_fits = single_line.width() as u16 + vpn_suffix_width
+                    <= help_block.width;
+
+                if one_line_fits {
+                    vec![single_line]
+                } else {
                     vec![
                         Line::from(vec![
                             Span::from("󱁐  or ↵ ").bold(),
@@ -913,49 +1119,45 @@ impl Station {
                             Span::from(" Internet"),
                         ]),
                     ]
-                } else {
-                    vec![Line::from(vec![
-                        Span::from("k,").bold(),
-                        Span::from("  Up"),
-                        Span::from(" | "),
-                        Span::from("j,").bold(),
-                        Span::from("  Down"),
-                        Span::from(" | "),
-                        Span::from("󱁐  or ↵ ").bold(),
-                        Span::from(" Dis/connect"),
-                        Span::from(" | "),
-                        Span::from(config.station.known_network.show_all.to_string()).bold(),
-                        Span::from(" Show All"),
-                        Span::from(" | "),
-                        Span::from(config.station.known_network.remove.to_string()).bold(),
-                        Span::from(" Remove"),
-                        Span::from(" | "),
-                        Span::from(config.station.known_network.toggle_autoconnect.to_string())
-                            .bold(),
-                        Span::from(" Autoconnect"),
-                        Span::from(" | "),
-                        Span::from(config.station.start_scanning.to_string()).bold(),
-                        Span::from(" Scan"),
-                        Span::from(" | "),
-                        Span::from(config.station.known_network.share.to_string()).bold(),
-                        Span::from(" Share"),
-                        Span::from(" | "),
-                        Span::from(config.station.known_network.speed_test.to_string()).bold(),
-                        Span::from(" Speed"),
-                        Span::from(" | "),
-                        Span::from(config.station.known_network.prefer.to_string()).bold(),
-                        Span::from(" Internet"),
-                        Span::from(" | "),
-                        Span::from("ctrl+r").bold(),
-                        Span::from(" Switch Mode"),
-                        Span::from(" | "),
-                        Span::from("⇄").bold(),
-                        Span::from(" Nav"),
-                    ])]
                 }
             }
             FocusedBlock::NewNetworks => {
-                if frame.area().width < 80 {
+                let single_line = Line::from(vec![
+                    Span::from("k,").bold(),
+                    Span::from("  Up"),
+                    Span::from(" | "),
+                    Span::from("j,").bold(),
+                    Span::from("  Down"),
+                    Span::from(" | "),
+                    Span::from("󱁐  or ↵ ").bold(),
+                    Span::from(" Connect"),
+                    Span::from(" | "),
+                    Span::from(config.station.new_network.connect_hidden.to_string()).bold(),
+                    Span::from(" Hidden"),
+                    Span::from(" | "),
+                    Span::from(config.station.new_network.show_all.to_string()).bold(),
+                    Span::from(" Show All"),
+                    Span::from(" | "),
+                    Span::from(config.station.new_network.filter.to_string()).bold(),
+                    Span::from(" Filter"),
+                    Span::from(" | "),
+                    Span::from(config.station.start_scanning.to_string()).bold(),
+                    Span::from(" Scan"),
+                    Span::from(" | "),
+                    Span::from("ctrl+r").bold(),
+                    Span::from(" Switch Mode"),
+                    Span::from(" | "),
+                    Span::from("⇄").bold(),
+                    Span::from(" Nav"),
+                ]);
+                let vpn_suffix_width =
+                    Line::from(crate::device::vpn_hint_spans(config.vpn)).width() as u16;
+                let one_line_fits = single_line.width() as u16 + vpn_suffix_width
+                    <= help_block.width;
+
+                if one_line_fits {
+                    vec![single_line]
+                } else {
                     vec![
                         Line::from(vec![
                             Span::from("󱁐  or ↵ ").bold(),
@@ -964,6 +1166,9 @@ impl Station {
                             Span::from(config.station.new_network.connect_hidden.to_string())
                                 .bold(),
                             Span::from(" Hidden"),
+                            Span::from(" | "),
+                            Span::from(config.station.new_network.filter.to_string()).bold(),
+                            Span::from(" Filter"),
                             Span::from(" | "),
                             Span::from(config.station.start_scanning.to_string()).bold(),
                             Span::from(" Scan"),
@@ -982,32 +1187,6 @@ impl Station {
                             Span::from(" Nav"),
                         ]),
                     ]
-                } else {
-                    vec![Line::from(vec![
-                        Span::from("k,").bold(),
-                        Span::from("  Up"),
-                        Span::from(" | "),
-                        Span::from("j,").bold(),
-                        Span::from("  Down"),
-                        Span::from(" | "),
-                        Span::from("󱁐  or ↵ ").bold(),
-                        Span::from(" Connect"),
-                        Span::from(" | "),
-                        Span::from(config.station.new_network.connect_hidden.to_string()).bold(),
-                        Span::from(" Hidden"),
-                        Span::from(" | "),
-                        Span::from(config.station.new_network.show_all.to_string()).bold(),
-                        Span::from(" Show All"),
-                        Span::from(" | "),
-                        Span::from(config.station.start_scanning.to_string()).bold(),
-                        Span::from(" Scan"),
-                        Span::from(" | "),
-                        Span::from("ctrl+r").bold(),
-                        Span::from(" Switch Mode"),
-                        Span::from(" | "),
-                        Span::from("⇄").bold(),
-                        Span::from(" Nav"),
-                    ])]
                 }
             }
             FocusedBlock::AdapterInfos => {

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -552,16 +552,23 @@ impl Station {
     }
 
     /// Border caption for the New Networks box while a filter is being typed or
-    /// is applied; `None` otherwise. Includes the live match count.
+    /// is applied; `None` otherwise. Includes the live match count and a
+    /// keys hint so the modal-style input is discoverable without docs.
     fn new_filter_caption(&self) -> Option<String> {
         if !self.filter_input && !self.new_filter_active() {
             return None;
         }
         let matches = self.visible_new_indices().len();
         if self.filter_input {
-            Some(format!(" / {}▏ ({matches}) ", self.filter_query))
+            Some(format!(
+                " / {}▏ ({matches}) · ↵ apply · esc cancel ",
+                self.filter_query
+            ))
         } else {
-            Some(format!(" filter: {} ({matches}) ", self.filter_query))
+            Some(format!(
+                " filter: {} ({matches}) · esc clears ",
+                self.filter_query
+            ))
         }
     }
 
@@ -1046,8 +1053,7 @@ impl Station {
                     Span::from(config.station.known_network.remove.to_string()).bold(),
                     Span::from(" Remove"),
                     Span::from(" | "),
-                    Span::from(config.station.known_network.toggle_autoconnect.to_string())
-                        .bold(),
+                    Span::from(config.station.known_network.toggle_autoconnect.to_string()).bold(),
                     Span::from(" Autoconnect"),
                     Span::from(" | "),
                     Span::from(config.station.start_scanning.to_string()).bold(),
@@ -1072,8 +1078,8 @@ impl Station {
                 // for it when deciding if the one-line layout fits.
                 let vpn_suffix_width =
                     Line::from(crate::device::vpn_hint_spans(config.vpn)).width() as u16;
-                let one_line_fits = single_line.width() as u16 + vpn_suffix_width
-                    <= help_block.width;
+                let one_line_fits =
+                    single_line.width() as u16 + vpn_suffix_width <= help_block.width;
 
                 if one_line_fits {
                     vec![single_line]
@@ -1152,8 +1158,8 @@ impl Station {
                 ]);
                 let vpn_suffix_width =
                     Line::from(crate::device::vpn_hint_spans(config.vpn)).width() as u16;
-                let one_line_fits = single_line.width() as u16 + vpn_suffix_width
-                    <= help_block.width;
+                let one_line_fits =
+                    single_line.width() as u16 + vpn_suffix_width <= help_block.width;
 
                 if one_line_fits {
                     vec![single_line]
@@ -1224,12 +1230,31 @@ impl Station {
             ])],
         };
 
+        // While the SSID filter input is active, override the help row with
+        // the keys that actually do something. The VPN hint is also skipped:
+        // `v` lands in the query, not the modal.
+        let typing_filter = focused_block == FocusedBlock::NewNetworks && self.filter_input;
+        if typing_filter {
+            help_message = vec![Line::from(vec![
+                Span::from(" ↵ ").bold(),
+                Span::from(" Apply"),
+                Span::from(" | "),
+                Span::from("󱊷 ").bold(),
+                Span::from(" Cancel"),
+                Span::from(" | "),
+                Span::from("⌫ ").bold(),
+                Span::from(" Delete"),
+            ])];
+        }
+
         // Advertise the global VPN shortcut from every list view by appending
         // it to the last help row.
-        if matches!(
-            focused_block,
-            FocusedBlock::Device | FocusedBlock::KnownNetworks | FocusedBlock::NewNetworks
-        ) && let Some(last) = help_message.last_mut()
+        if !typing_filter
+            && matches!(
+                focused_block,
+                FocusedBlock::Device | FocusedBlock::KnownNetworks | FocusedBlock::NewNetworks
+            )
+            && let Some(last) = help_message.last_mut()
         {
             last.spans.extend(crate::device::vpn_hint_spans(config.vpn));
         }


### PR DESCRIPTION
Three daily-ops additions:

- **Device box footer shows the adapter's LAN IP** (e.g. `󰩟 wlan0 · 192.168.1.20`) so you can SSH in without `ip addr`.
- **Filter the New Networks scan list by SSID** with `/` — the long list problem in dense areas.
- **Captive-portal helper**: the internet caption flags when you're connected but offline; `l` opens the login page (`xdg-open`, with a neutral-trigger fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSID filtering for the “New Networks” scan list: press `/` to start, type to filter, use `Enter` to apply and `Esc` to cancel, with a match-count caption.
  * Shows the active adapter’s LAN IP in the device panel footer for easier SSH access.

* **Bug Fixes**
  * Improved key handling during SSID input so global shortcuts don’t trigger; `Esc` reliably clears the applied filter.
  * Hidden-network rows no longer render while an SSID filter is active.

* **Documentation**
  * Updated default-route highlighting clarification and added the new filter binding (`filter = "/"`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->