### PR TITLE
fix(station): surface wifi connect outcome and detect wrong password

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -499,7 +499,7 @@ pub async fn handle_key_events(
                                 app.auth.hidden.reset();
                                 app.focused_block = FocusedBlock::NewNetworks;
                                 tokio::spawn(async move {
-                                    let _ = station_client
+                                    match station_client
                                         .add_and_activate_hidden_connection(
                                             &device_path,
                                             &ssid,
@@ -507,20 +507,25 @@ pub async fn handle_key_events(
                                             password.as_deref(),
                                         )
                                         .await
-                                        .map(|_| {
-                                            let _ = Notification::send(
-                                                format!("Connecting to hidden network: {}", ssid),
-                                                notification::NotificationLevel::Info,
-                                                &sender_clone,
-                                            );
-                                        })
-                                        .map_err(|e| {
+                                    {
+                                        Ok(active_path) => {
+                                            crate::mode::station::network::watch_activation(
+                                                station_client,
+                                                active_path.to_string(),
+                                                device_path,
+                                                ssid,
+                                                sender_clone,
+                                            )
+                                            .await;
+                                        }
+                                        Err(e) => {
                                             let _ = Notification::send(
                                                 format!("Failed to connect to {}: {}", ssid, e),
                                                 notification::NotificationLevel::Error,
                                                 &sender_clone,
                                             );
-                                        });
+                                        }
+                                    }
                                 });
                             }
                         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -584,18 +584,37 @@ pub async fn handle_key_events(
                         KeyCode::Enter => {
                             // Get the password before submit() resets it
                             let password: String = app.auth.psk.passphrase.value().into();
-                            app.auth.psk.submit(&app.agent).await?;
 
-                            // Connect to the pending network with the password
-                            if let Some(net) = app.network_pending_auth.take() {
-                                let sender_clone = sender.clone();
-                                tokio::spawn(async move {
-                                    let _ = net.connect(sender_clone, Some(&password)).await;
-                                });
+                            // Validate against the network's security type
+                            // before handing the secret to NetworkManager: a
+                            // too-short WPA/WPA2-PSK passphrase fails here with a
+                            // clear message instead of as an opaque activation
+                            // error. SAE/WEP/Enterprise impose no such rule.
+                            let validation = app
+                                .network_pending_auth
+                                .as_ref()
+                                .map_or(Ok(()), |net| net.network_type.validate_psk(&password));
+
+                            if let Err(msg) = validation {
+                                Notification::send(
+                                    msg.to_string(),
+                                    notification::NotificationLevel::Error,
+                                    &sender,
+                                )?;
+                            } else {
+                                app.auth.psk.submit(&app.agent).await?;
+
+                                // Connect to the pending network with the password
+                                if let Some(net) = app.network_pending_auth.take() {
+                                    let sender_clone = sender.clone();
+                                    tokio::spawn(async move {
+                                        let _ = net.connect(sender_clone, Some(&password)).await;
+                                    });
+                                }
+
+                                app.network_name_requiring_auth = None;
+                                app.focused_block = FocusedBlock::NewNetworks;
                             }
-
-                            app.network_name_requiring_auth = None;
-                            app.focused_block = FocusedBlock::NewNetworks;
                         }
 
                         KeyCode::Esc => {

--- a/src/mode/ap.rs
+++ b/src/mode/ap.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::sync::{Arc, atomic::AtomicBool};
 
-use crate::nm::NMClient;
+use crate::nm::{NMClient, SecurityType};
 use tokio::sync::mpsc::UnboundedSender;
 
 use ratatui::{
@@ -307,12 +307,10 @@ impl AccessPoint {
             return Ok(());
         }
 
-        if psk.len() < 8 {
-            Notification::send(
-                "Password must be at least 8 characters".to_string(),
-                NotificationLevel::Error,
-                &sender,
-            )?;
+        // A hotspot is always WPA2-PSK, so it is bound by the WPA passphrase
+        // length rule — validate through the shared policy.
+        if let Err(msg) = SecurityType::WPA2.validate_psk(&psk) {
+            Notification::send(msg.to_string(), NotificationLevel::Error, &sender)?;
             return Ok(());
         }
 

--- a/src/mode/station/network.rs
+++ b/src/mode/station/network.rs
@@ -2,13 +2,74 @@ use anyhow::Result;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::nm::{AccessPointInfo, NMClient, SecurityType};
+use crate::nm::{
+    AccessPointInfo, ActivationFailureReason, ActivationOutcome, NMClient, SecurityType,
+};
 
 use crate::{
     event::Event,
     mode::station::known_network::KnownNetwork,
     notification::{Notification, NotificationLevel},
 };
+
+/// Drive a freshly-started WiFi activation to its terminal state and surface
+/// the result to the user.
+///
+/// Call sites are responsible for *starting* the activation (via
+/// `add_and_activate_connection`, `activate_connection`, or
+/// `add_and_activate_hidden_connection`) and handing this helper the resulting
+/// active-connection path. The helper then:
+///   1. emits an `"Associating with …"` info notification,
+///   2. waits on the NM state machine,
+///   3. emits exactly one terminal notification — success, bad-password, or
+///      generic failure.
+///
+/// Notification send-errors are intentionally swallowed: by the time we have
+/// an activation outcome the caller has typically been spawned onto a
+/// background task with no error path back to the UI thread.
+pub async fn watch_activation(
+    client: Arc<NMClient>,
+    active_path: String,
+    device_path: String,
+    ssid: String,
+    sender: UnboundedSender<Event>,
+) {
+    let _ = Notification::send(
+        format!("Associating with {}…", ssid),
+        NotificationLevel::Info,
+        &sender,
+    );
+
+    let outcome = match client.await_activation(&active_path, &device_path).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            let _ = Notification::send(
+                format!("Failed to monitor connection to {}: {}", ssid, e),
+                NotificationLevel::Error,
+                &sender,
+            );
+            return;
+        }
+    };
+
+    let (message, level) = match outcome {
+        ActivationOutcome::Activated => (format!("Connected to {}", ssid), NotificationLevel::Info),
+        ActivationOutcome::Failed(ActivationFailureReason::BadSecrets) => (
+            format!("Wrong password for {}", ssid),
+            NotificationLevel::Error,
+        ),
+        ActivationOutcome::Failed(ActivationFailureReason::Timeout) => (
+            format!("Connection to {} timed out", ssid),
+            NotificationLevel::Error,
+        ),
+        ActivationOutcome::Failed(ActivationFailureReason::Other(code)) => (
+            format!("Failed to connect to {} (reason {})", ssid, code),
+            NotificationLevel::Error,
+        ),
+    };
+
+    let _ = Notification::send(message, level, &sender);
+}
 
 #[derive(Debug, Clone)]
 pub struct Network {
@@ -47,58 +108,46 @@ impl Network {
         sender: UnboundedSender<Event>,
         password: Option<&str>,
     ) -> Result<()> {
-        // Check if we have a saved connection for this network
-        if let Some(known) = &self.known_network {
-            // Use existing connection profile
-            match self
-                .client
+        // Kick off the activation. Each branch produces either an active
+        // connection path (success) or a D-Bus-level error (start failure).
+        let start_result = if let Some(known) = &self.known_network {
+            self.client
                 .activate_connection(&known.connection_path, &self.device_path)
                 .await
-            {
-                Ok(_) => {
-                    Notification::send(
-                        format!("Connecting to {}", self.name),
-                        NotificationLevel::Info,
-                        &sender,
-                    )?;
-                }
-                Err(e) => {
-                    Notification::send(
-                        format!("Failed to connect: {}", e),
-                        NotificationLevel::Error,
-                        &sender,
-                    )?;
-                }
-            }
         } else {
-            // Create new connection
-            match self
-                .client
+            self.client
                 .add_and_activate_connection(&self.device_path, &self.ap_path, password)
                 .await
-            {
-                Ok(_) => {
-                    Notification::send(
-                        format!("Connecting to {}", self.name),
-                        NotificationLevel::Info,
-                        &sender,
-                    )?;
+        };
+
+        match start_result {
+            Ok(active_path) => {
+                tokio::spawn(watch_activation(
+                    self.client.clone(),
+                    active_path.to_string(),
+                    self.device_path.clone(),
+                    self.name.clone(),
+                    sender,
+                ));
+                Ok(())
+            }
+            Err(e) => {
+                // A missing password on a secured new-network attempt is not a
+                // user-visible failure — it's the trigger for the auth flow.
+                if self.known_network.is_none()
+                    && self.network_type.requires_password()
+                    && password.is_none()
+                {
+                    return Err(anyhow::anyhow!("Password required"));
                 }
-                Err(e) => {
-                    // Check if password is required
-                    if self.network_type.requires_password() && password.is_none() {
-                        // Password required - this will be handled by the auth flow
-                        return Err(anyhow::anyhow!("Password required"));
-                    }
-                    Notification::send(
-                        format!("Failed to connect: {}", e),
-                        NotificationLevel::Error,
-                        &sender,
-                    )?;
-                }
+                Notification::send(
+                    format!("Failed to connect: {}", e),
+                    NotificationLevel::Error,
+                    &sender,
+                )?;
+                Ok(())
             }
         }
-        Ok(())
     }
 
     pub fn requires_password(&self) -> bool {

--- a/src/mode/station/network.rs
+++ b/src/mode/station/network.rs
@@ -58,6 +58,13 @@ pub async fn watch_activation(
             format!("Wrong password for {}", ssid),
             NotificationLevel::Error,
         ),
+        ActivationOutcome::Failed(ActivationFailureReason::SsidNotFound) => (
+            format!(
+                "Could not connect to {} — wrong password or network out of range",
+                ssid
+            ),
+            NotificationLevel::Error,
+        ),
         ActivationOutcome::Failed(ActivationFailureReason::Timeout) => (
             format!("Connection to {} timed out", ssid),
             NotificationLevel::Error,

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -1250,7 +1250,7 @@ impl NMClient {
         active_path: &str,
         device_path: &str,
     ) -> Result<ActivationOutcome> {
-        use futures::StreamExt;
+        use futures::{FutureExt, StreamExt};
 
         const ACTIVATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
@@ -1272,6 +1272,26 @@ impl NMClient {
         let mut ac_signals = ac_proxy.receive_signal("StateChanged").await?;
         let mut dev_signals = dev_proxy.receive_signal("StateChanged").await?;
 
+        // Non-blocking drain of any device signals that are ready *right now*,
+        // updating `last` with the latest `Failed`-transition reason seen.
+        // Used at every "I am about to classify a failure" point so we never
+        // race past a queued device reason — `tokio::select!` picks ready
+        // branches at random, and the fast path below intentionally bypasses
+        // the loop entirely.
+        macro_rules! drain_dev_failure_reason {
+            ($last:expr) => {
+                while let Some(opt) = dev_signals.next().now_or_never() {
+                    let Some(msg) = opt else { break };
+                    if let Ok((new_state, _old_state, reason)) =
+                        msg.body().deserialize::<(u32, u32, u32)>()
+                        && DeviceState::from(new_state) == DeviceState::Failed
+                    {
+                        $last = Some(reason);
+                    }
+                }
+            };
+        }
+
         // Fast path: if the active connection is already terminal at
         // subscription time, decide now. We deliberately don't peek at the
         // device's current state — a fallback activation may have already
@@ -1280,7 +1300,15 @@ impl NMClient {
             match ActiveConnectionState::from(current) {
                 ActiveConnectionState::Activated => return Ok(ActivationOutcome::Activated),
                 ActiveConnectionState::Deactivated => {
-                    return Ok(ActivationOutcome::Failed(ActivationFailureReason::Other(0)));
+                    // The AC StateChanged signal may pre-date our subscription
+                    // (and so be lost), but device signals emitted between
+                    // subscription and now are still queued.
+                    let mut last: Option<u32> = None;
+                    drain_dev_failure_reason!(last);
+                    return Ok(ActivationOutcome::Failed(match last {
+                        Some(r) => ActivationFailureReason::from_nm_device_reason(r),
+                        None => ActivationFailureReason::Other(0),
+                    }));
                 }
                 _ => {}
             }
@@ -1306,6 +1334,11 @@ impl NMClient {
                                 return ActivationOutcome::Activated;
                             }
                             ActiveConnectionState::Deactivated => {
+                                // select! ordering is random: a Device.Failed
+                                // signal may be queued alongside this one.
+                                // Drain before classifying so we don't lose
+                                // the canonical wifi-layer reason.
+                                drain_dev_failure_reason!(last_device_failure_reason);
                                 let reason = match last_device_failure_reason {
                                     Some(r) => ActivationFailureReason::from_nm_device_reason(r),
                                     None => ActivationFailureReason::from_nm_active_reason(ac_reason),

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -1227,6 +1227,118 @@ impl NMClient {
         })
     }
 
+    /// Wait for an activation attempt to reach a terminal state.
+    ///
+    /// Returns once the active connection is `Activated` or `Deactivated`, or
+    /// after `ACTIVATION_TIMEOUT` if NM never settles.
+    ///
+    /// Watches **two** signal streams concurrently:
+    ///
+    /// * `Connection.Active.StateChanged` decides *when* we are done — it is
+    ///   the unambiguous terminal event for our specific activation attempt.
+    /// * `Device.StateChanged` is what carries the canonical failure reason
+    ///   for the wifi case. The Active-Connection layer collapses every
+    ///   device-side failure into reason `3` (`DeviceDisconnected`), which is
+    ///   useless to the user; the Device emits the real
+    ///   `NMDeviceStateReason` (e.g. `NoSecrets`, `SupplicantDisconnect`)
+    ///   on its transition into `Failed`.
+    ///
+    /// We cache the most recent device failure reason and surface it the
+    /// instant the active connection reports `Deactivated`.
+    pub async fn await_activation(
+        &self,
+        active_path: &str,
+        device_path: &str,
+    ) -> Result<ActivationOutcome> {
+        use futures::StreamExt;
+
+        const ACTIVATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
+        let ac_proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            active_path,
+            "org.freedesktop.NetworkManager.Connection.Active",
+        )
+        .await?;
+        let dev_proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            device_path,
+            "org.freedesktop.NetworkManager.Device",
+        )
+        .await?;
+
+        let mut ac_signals = ac_proxy.receive_signal("StateChanged").await?;
+        let mut dev_signals = dev_proxy.receive_signal("StateChanged").await?;
+
+        // Fast path: if the active connection is already terminal at
+        // subscription time, decide now. We deliberately don't peek at the
+        // device's current state — a fallback activation may have already
+        // raced past Failed, in which case the property would mislead us.
+        if let Ok(current) = ac_proxy.get_property::<u32>("State").await {
+            match ActiveConnectionState::from(current) {
+                ActiveConnectionState::Activated => return Ok(ActivationOutcome::Activated),
+                ActiveConnectionState::Deactivated => {
+                    return Ok(ActivationOutcome::Failed(ActivationFailureReason::Other(0)));
+                }
+                _ => {}
+            }
+        }
+
+        let wait = async {
+            // Most recent reason observed for a device transition into Failed.
+            // Stays at `None` until we actually see Failed; a falsy/0 reason
+            // would otherwise be indistinguishable from "never seen".
+            let mut last_device_failure_reason: Option<u32> = None;
+            // Once a stream ends it would immediately re-yield `Ready(None)`
+            // on every poll; gate each branch so `select!` stops polling it.
+            let mut dev_done = false;
+            loop {
+                tokio::select! {
+                    msg = ac_signals.next() => {
+                        let Some(msg) = msg else { break };
+                        let Ok((state, ac_reason)) = msg.body().deserialize::<(u32, u32)>() else {
+                            continue;
+                        };
+                        match ActiveConnectionState::from(state) {
+                            ActiveConnectionState::Activated => {
+                                return ActivationOutcome::Activated;
+                            }
+                            ActiveConnectionState::Deactivated => {
+                                let reason = match last_device_failure_reason {
+                                    Some(r) => ActivationFailureReason::from_nm_device_reason(r),
+                                    None => ActivationFailureReason::from_nm_active_reason(ac_reason),
+                                };
+                                return ActivationOutcome::Failed(reason);
+                            }
+                            _ => continue,
+                        }
+                    }
+                    msg = dev_signals.next(), if !dev_done => {
+                        let Some(msg) = msg else {
+                            dev_done = true;
+                            continue;
+                        };
+                        let Ok((new_state, _old_state, reason)) =
+                            msg.body().deserialize::<(u32, u32, u32)>()
+                        else {
+                            continue;
+                        };
+                        if DeviceState::from(new_state) == DeviceState::Failed {
+                            last_device_failure_reason = Some(reason);
+                        }
+                    }
+                }
+            }
+            ActivationOutcome::Failed(ActivationFailureReason::Other(0))
+        };
+
+        Ok(tokio::time::timeout(ACTIVATION_TIMEOUT, wait)
+            .await
+            .unwrap_or(ActivationOutcome::Failed(ActivationFailureReason::Timeout)))
+    }
+
     /// Create a WiFi hotspot
     pub async fn create_hotspot(
         &self,

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -246,6 +246,9 @@ impl From<u32> for WifiMode {
     }
 }
 
+/// Minimum length of a WPA/WPA2-PSK passphrase, per the WPA spec (8–63 ASCII).
+pub const WPA_PSK_MIN_LEN: usize = 8;
+
 /// Security type for WiFi networks
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SecurityType {
@@ -297,6 +300,21 @@ impl SecurityType {
 
     pub fn is_enterprise(&self) -> bool {
         matches!(self, SecurityType::Enterprise)
+    }
+
+    /// Validate a PSK passphrase against this security type's length rules,
+    /// returning a user-facing message on failure.
+    ///
+    /// Only WPA/WPA2-PSK impose the WPA minimum ([`WPA_PSK_MIN_LEN`]). WPA3-SAE
+    /// has no minimum-length requirement, WEP uses its own 5/13-char key
+    /// lengths, and Enterprise authenticates with EAP credentials (not via the
+    /// PSK prompt), so all of those pass here and are left to NetworkManager's
+    /// own validation.
+    pub fn validate_psk(&self, psk: &str) -> Result<(), &'static str> {
+        if matches!(self, SecurityType::WPA | SecurityType::WPA2) && psk.len() < WPA_PSK_MIN_LEN {
+            return Err("Password must be at least 8 characters");
+        }
+        Ok(())
     }
 }
 
@@ -425,6 +443,12 @@ impl From<u32> for ActiveConnectionState {
 pub enum ActivationFailureReason {
     /// Wrong / missing passphrase (NM reasons `NoSecrets` and `LoginFailed`).
     BadSecrets,
+    /// NM reported the SSID could not be found (device reason `SsidNotFound`,
+    /// 53). This is genuinely ambiguous: NM emits it both when the network is
+    /// out of range / gone and, on many drivers, when a wrong PSK fails the
+    /// 4-way handshake and the AP deauthenticates. We surface it honestly
+    /// rather than guessing "wrong password".
+    SsidNotFound,
     /// Activation did not reach a terminal state within our wait window.
     Timeout,
     /// Any other terminal failure; carries the raw NM reason code so callers
@@ -457,8 +481,12 @@ impl ActivationFailureReason {
         // 8  = NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT
         // 9  = NM_DEVICE_STATE_REASON_SUPPLICANT_CONFIG_FAILED
         // 10 = NM_DEVICE_STATE_REASON_SUPPLICANT_FAILED
+        // 53 = NM_DEVICE_STATE_REASON_SSID_NOT_FOUND (also a common
+        //      wrong-PSK symptom — see `SsidNotFound`, kept distinct so the
+        //      message stays truthful rather than asserting "wrong password").
         match reason {
             7..=10 => Self::BadSecrets,
+            53 => Self::SsidNotFound,
             other => Self::Other(other),
         }
     }
@@ -729,6 +757,12 @@ mod tests {
                 code
             );
         }
+        // 53 = SSID_NOT_FOUND: kept distinct so the message stays honest
+        // rather than asserting a wrong password.
+        assert_eq!(
+            ActivationFailureReason::from_nm_device_reason(53),
+            ActivationFailureReason::SsidNotFound
+        );
         assert_eq!(
             ActivationFailureReason::from_nm_device_reason(0),
             ActivationFailureReason::Other(0)
@@ -737,5 +771,27 @@ mod tests {
             ActivationFailureReason::from_nm_device_reason(6),
             ActivationFailureReason::Other(6)
         );
+    }
+
+    #[test]
+    fn test_validate_psk_enforces_min_only_for_wpa_psk() {
+        // WPA/WPA2-PSK reject short passphrases but accept >= 8.
+        for ty in [SecurityType::WPA, SecurityType::WPA2] {
+            assert!(ty.validate_psk("short").is_err(), "{:?} short", ty);
+            assert!(ty.validate_psk("12345678").is_ok(), "{:?} 8 chars", ty);
+        }
+        // WPA3-SAE has no minimum; WEP/Enterprise/Open are not PSK prompts.
+        for ty in [
+            SecurityType::WPA3,
+            SecurityType::WEP,
+            SecurityType::Enterprise,
+            SecurityType::Open,
+        ] {
+            assert!(
+                ty.validate_psk("short").is_ok(),
+                "{:?} should not enforce the 8-char PSK rule",
+                ty
+            );
+        }
     }
 }

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -418,6 +418,59 @@ impl From<u32> for ActiveConnectionState {
     }
 }
 
+/// Classification of why an activation attempt did not reach `Activated`.
+/// Maps NetworkManager's `NMActiveConnectionStateReason` codes into the
+/// distinctions the UI actually surfaces to the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationFailureReason {
+    /// Wrong / missing passphrase (NM reasons `NoSecrets` and `LoginFailed`).
+    BadSecrets,
+    /// Activation did not reach a terminal state within our wait window.
+    Timeout,
+    /// Any other terminal failure; carries the raw NM reason code so callers
+    /// can log it without inventing a name for every value.
+    Other(u32),
+}
+
+impl ActivationFailureReason {
+    /// Map a raw `NMActiveConnectionStateReason` to our classification.
+    ///
+    /// The Active-Connection layer almost always reports `DeviceDisconnected`
+    /// (3) when the real failure happened at the device layer — use
+    /// [`Self::from_nm_device_reason`] in tandem to get the canonical reason.
+    pub fn from_nm_active_reason(reason: u32) -> Self {
+        // 9  = NM_ACTIVE_CONNECTION_STATE_REASON_NO_SECRETS
+        // 10 = NM_ACTIVE_CONNECTION_STATE_REASON_LOGIN_FAILED
+        match reason {
+            9 | 10 => Self::BadSecrets,
+            other => Self::Other(other),
+        }
+    }
+
+    /// Map a raw `NMDeviceStateReason` to our classification.
+    ///
+    /// This is where the wifi-specific auth-failure signals actually live —
+    /// the Active-Connection signal only ever reports `DeviceDisconnected` (3)
+    /// for these cases, which is useless to the user.
+    pub fn from_nm_device_reason(reason: u32) -> Self {
+        // 7  = NM_DEVICE_STATE_REASON_NO_SECRETS
+        // 8  = NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT
+        // 9  = NM_DEVICE_STATE_REASON_SUPPLICANT_CONFIG_FAILED
+        // 10 = NM_DEVICE_STATE_REASON_SUPPLICANT_FAILED
+        match reason {
+            7..=10 => Self::BadSecrets,
+            other => Self::Other(other),
+        }
+    }
+}
+
+/// Terminal result of waiting on an active connection's state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationOutcome {
+    Activated,
+    Failed(ActivationFailureReason),
+}
+
 /// Active connection info
 #[derive(Debug, Clone)]
 pub struct ActiveConnectionInfo {
@@ -641,6 +694,48 @@ mod tests {
         assert_eq!(
             ActiveConnectionState::from(4),
             ActiveConnectionState::Deactivated
+        );
+    }
+
+    #[test]
+    fn test_activation_failure_reason_from_nm_active_reason() {
+        assert_eq!(
+            ActivationFailureReason::from_nm_active_reason(9),
+            ActivationFailureReason::BadSecrets
+        );
+        assert_eq!(
+            ActivationFailureReason::from_nm_active_reason(10),
+            ActivationFailureReason::BadSecrets
+        );
+        // 3 (DeviceDisconnected) is the AC-layer code we see for device-side
+        // auth failures — must NOT classify as BadSecrets at this layer.
+        assert_eq!(
+            ActivationFailureReason::from_nm_active_reason(3),
+            ActivationFailureReason::Other(3)
+        );
+        assert_eq!(
+            ActivationFailureReason::from_nm_active_reason(0),
+            ActivationFailureReason::Other(0)
+        );
+    }
+
+    #[test]
+    fn test_activation_failure_reason_from_nm_device_reason() {
+        for code in [7, 8, 9, 10] {
+            assert_eq!(
+                ActivationFailureReason::from_nm_device_reason(code),
+                ActivationFailureReason::BadSecrets,
+                "device reason {} should classify as BadSecrets",
+                code
+            );
+        }
+        assert_eq!(
+            ActivationFailureReason::from_nm_device_reason(0),
+            ActivationFailureReason::Other(0)
+        );
+        assert_eq!(
+            ActivationFailureReason::from_nm_device_reason(6),
+            ActivationFailureReason::Other(6)
         );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hidden Wi‑Fi connection feedback with clearer, single final status messages.
  * Connection attempts now wait for activation to finish before showing results, reducing misleading success notifications.
  * Failure reporting is more specific, including incorrect credentials and connection timeouts.
* **Security**
  * Passphrases are now validated against the expected WPA/WPA2 security requirements before attempting connections (including AP and Station flows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->