### PR TITLE
Make wlctl use way less CPU when it is just sitting there

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,6 +136,10 @@ mode = "station"
 esc_quit = false
 vpn = "v"
 
+# How often to re-read NetworkManager state, in milliseconds.
+# Raise it to trade responsiveness for less background work.
+refresh_interval_ms = 1000
+
 [device]
 infos = "i"
 toggle_power = "o"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -13,10 +13,8 @@ use crate::config::Config;
 
 #[derive(Debug, Clone)]
 pub struct Adapter {
-    client: Arc<NMClient>,
     #[allow(dead_code)]
     device_path: String,
-    pub is_powered: bool,
     pub name: String,
     pub driver: Option<String>,
     pub vendor: Option<String>,
@@ -30,7 +28,6 @@ impl Adapter {
         device_path: String,
         config: Arc<Config>,
     ) -> Result<Self> {
-        let is_powered = client.is_wireless_enabled().await?;
         let name = client.get_device_interface(&device_path).await?;
 
         // NetworkManager doesn't expose driver/vendor info directly via D-Bus
@@ -43,20 +40,13 @@ impl Adapter {
         let supported_modes = vec!["station".to_string(), "ap".to_string()];
 
         Ok(Self {
-            client,
             device_path,
-            is_powered,
             name,
             driver,
             vendor,
             supported_modes,
             config,
         })
-    }
-
-    pub async fn refresh(&mut self) -> Result<()> {
-        self.is_powered = self.client.is_wireless_enabled().await?;
-        Ok(())
     }
 
     pub fn render(&self, frame: &mut Frame, device_addr: String) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -381,7 +381,7 @@ Error: {}",
         }
 
         self.device.refresh().await?;
-        self.adapter.refresh().await?;
+        self.adapter.is_powered = self.device.is_powered;
 
         // Keep the VPN modal's on/off state live while it's open.
         if let Some(modal) = &mut self.vpn {
@@ -397,6 +397,9 @@ Error: {}",
         // Refresh wired link status. Best-effort, and intentionally independent
         // of the WiFi power state so it stays visible when the radio is off.
         if let Ok(eth) = self.client.active_ethernet().await {
+            if let Some(station) = &mut self.device.station {
+                station.is_ethernet_connected = eth.is_some();
+            }
             self.ethernet = eth;
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -358,8 +358,7 @@ Error: {}",
     }
 
     pub async fn tick(&mut self) -> Result<()> {
-        self.notifications.retain(|n| n.ttl > 0);
-        self.notifications.iter_mut().for_each(|n| n.ttl -= 1);
+        self.notifications.retain(|n| !n.is_expired());
 
         // One read of NetworkManager's object graph serves every refresh below,
         // so they all describe the same instant and cost one round trip between

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use zbus::zvariant::OwnedObjectPath;
 
-use crate::nm::{EthernetInfo, Mode, NMClient, PrimaryLink};
+use crate::nm::{EthernetInfo, Mode, NMClient, NmSnapshot, PrimaryLink};
 
 use crate::{
     adapter::Adapter, agent::AuthAgent, config::Config, device::Device, doctor::DoctorModal,
@@ -48,18 +48,16 @@ pub struct AdapterSummary {
 }
 
 impl AdapterSummary {
-    async fn fetch(client: &NMClient, path: OwnedObjectPath) -> Result<Self> {
-        let name = client.get_device_interface(path.as_str()).await?;
-        Ok(Self { path, name })
-    }
-
-    async fn fetch_all(client: &NMClient) -> Result<Vec<Self>> {
-        let paths = client.get_wifi_devices().await?;
-        let mut out = Vec::with_capacity(paths.len());
-        for p in paths {
-            out.push(Self::fetch(client, p).await?);
-        }
-        Ok(out)
+    /// Every WiFi adapter described by `snapshot`, in NetworkManager's order.
+    fn all(snapshot: &NmSnapshot) -> Vec<Self> {
+        snapshot
+            .wifi_devices()
+            .into_iter()
+            .map(|path| {
+                let name = snapshot.device_interface(path.as_str()).unwrap_or_default();
+                Self { path, name }
+            })
+            .collect()
     }
 }
 
@@ -192,11 +190,13 @@ Error: {}",
             }
         };
 
-        let adapters = AdapterSummary::fetch_all(&client).await?;
+        // One snapshot answers the adapter list and the wired-link state, so
+        // the station is built already knowing both.
+        let snapshot = NmSnapshot::fetch(&client).await?;
+        let adapters = AdapterSummary::all(&snapshot);
         if adapters.is_empty() {
             return Err(anyhow!("No WiFi device found"));
         }
-
         let active_index = 0;
         let mut device = Device::new(client.clone(), adapters[active_index].path.clone()).await?;
 
@@ -339,10 +339,15 @@ Error: {}",
         self.notifications.retain(|n| n.ttl > 0);
         self.notifications.iter_mut().for_each(|n| n.ttl -= 1);
 
+        // One read of NetworkManager's object graph serves every refresh below,
+        // so they all describe the same instant and cost one round trip between
+        // them instead of one per object.
+        let snapshot = NmSnapshot::fetch(&self.client).await?;
+
         // Refresh the adapter list; if the active path disappeared, fall back to
         // the first remaining device. `adapters` is only committed after any
         // fallible activation so `self` stays consistent on error.
-        let current = AdapterSummary::fetch_all(&self.client).await?;
+        let current = AdapterSummary::all(&snapshot);
         let paths_changed = current.len() != self.adapters.len()
             || current
                 .iter()
@@ -380,22 +385,19 @@ Error: {}",
                 .unwrap_or(self.active_index);
         }
 
-        self.device.refresh().await?;
+        self.device.refresh(&snapshot).await?;
 
         // Keep the VPN modal's on/off state live while it's open.
         if let Some(modal) = &mut self.vpn {
             modal.refresh(&self.client).await?;
         }
 
-        // Refresh the always-on VPN badge. Best-effort: a transient D-Bus error
-        // shouldn't take down the whole tick, so failures just leave it stale.
-        if let Ok(names) = self.client.get_active_vpn_names().await {
-            self.active_vpns = names;
-        }
+        // Refresh the always-on VPN badge.
+        self.active_vpns = self.client.active_vpn_names(&snapshot);
 
         // Refresh wired link status. Best-effort, and intentionally independent
         // of the WiFi power state so it stays visible when the radio is off.
-        if let Ok(eth) = self.client.active_ethernet().await {
+        if let Ok(eth) = self.client.active_ethernet(&snapshot).await {
             if let Some(station) = &mut self.device.station {
                 station.is_ethernet_connected = eth.is_some();
             }
@@ -403,9 +405,7 @@ Error: {}",
         }
 
         // Refresh which link owns the default route (the live internet path).
-        if let Ok(primary) = self.client.primary_link().await {
-            self.primary_link = primary;
-        }
+        self.primary_link = self.client.primary_link(&snapshot);
 
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -197,8 +197,15 @@ Error: {}",
         if adapters.is_empty() {
             return Err(anyhow!("No WiFi device found"));
         }
+        let ethernet = client.active_ethernet(&snapshot).await.unwrap_or(None);
+
         let active_index = 0;
-        let mut device = Device::new(client.clone(), adapters[active_index].path.clone()).await?;
+        let mut device = Device::new(
+            client.clone(),
+            adapters[active_index].path.clone(),
+            ethernet.is_some(),
+        )
+        .await?;
 
         let adapter =
             match Adapter::new(client.clone(), device.device_path.clone(), config.clone()).await {
@@ -208,7 +215,7 @@ Error: {}",
                 }
             };
 
-        device.set_mode(mode).await?;
+        device.set_mode(mode, ethernet.is_some()).await?;
 
         let agent = AuthAgent::new(sender);
 
@@ -236,7 +243,7 @@ Error: {}",
             doctor_run_id: 0,
             vpn: None,
             active_vpns: Vec::new(),
-            ethernet: None,
+            ethernet,
             primary_link: None,
         })
     }
@@ -276,7 +283,8 @@ Error: {}",
             .clone();
         let previous_mode = self.device.mode;
 
-        self.activate_device(target, previous_mode).await?;
+        self.activate_device(target, previous_mode, self.ethernet.is_some())
+            .await?;
         self.active_index = self.adapter_selection_index;
         Ok(())
     }
@@ -295,9 +303,16 @@ Error: {}",
     // Builds a Device + Adapter for the given path and only commits them to `self`
     // after every await has succeeded. Callers update `active_index`/`adapters`
     // after this returns Ok, so `self` stays consistent on failure.
-    async fn activate_device(&mut self, path: OwnedObjectPath, preserve_mode: Mode) -> Result<()> {
-        let mut new_device = Device::new(self.client.clone(), path).await?;
-        new_device.set_mode(preserve_mode).await?;
+    async fn activate_device(
+        &mut self,
+        path: OwnedObjectPath,
+        preserve_mode: Mode,
+        is_ethernet_connected: bool,
+    ) -> Result<()> {
+        let mut new_device = Device::new(self.client.clone(), path, is_ethernet_connected).await?;
+        new_device
+            .set_mode(preserve_mode, is_ethernet_connected)
+            .await?;
         let new_adapter = Adapter::new(
             self.client.clone(),
             new_device.device_path.clone(),
@@ -326,12 +341,19 @@ Error: {}",
             .next()
             .ok_or_else(|| anyhow!("No WiFi device found"))?;
 
-        let mut device = match Device::new(client.clone(), path).await {
+        let snapshot = NmSnapshot::fetch(&client).await?;
+        let is_ethernet_connected = client
+            .active_ethernet(&snapshot)
+            .await
+            .unwrap_or(None)
+            .is_some();
+
+        let mut device = match Device::new(client.clone(), path, is_ethernet_connected).await {
             Ok(v) => v,
             Err(e) => return Err(anyhow!("Can not access the NetworkManager service: {}", e)),
         };
 
-        device.set_mode(mode).await?;
+        device.set_mode(mode, is_ethernet_connected).await?;
         Ok(())
     }
 
@@ -343,6 +365,15 @@ Error: {}",
         // so they all describe the same instant and cost one round trip between
         // them instead of one per object.
         let snapshot = NmSnapshot::fetch(&self.client).await?;
+
+        // Resolved before anything below can build a station, so a station born
+        // during this tick starts with the right wired state instead of a
+        // default it would carry until the next one.
+        let ethernet = self
+            .client
+            .active_ethernet(&snapshot)
+            .await
+            .unwrap_or_else(|_| self.ethernet.clone());
 
         // Refresh the adapter list; if the active path disappeared, fall back to
         // the first remaining device. `adapters` is only committed after any
@@ -374,7 +405,8 @@ Error: {}",
                     }
                     let previous_mode = self.device.mode;
                     let fallback = current[0].path.clone();
-                    self.activate_device(fallback, previous_mode).await?;
+                    self.activate_device(fallback, previous_mode, ethernet.is_some())
+                        .await?;
                     self.active_index = 0;
                     self.adapters = current;
                 }
@@ -385,7 +417,7 @@ Error: {}",
                 .unwrap_or(self.active_index);
         }
 
-        self.device.refresh(&snapshot).await?;
+        self.device.refresh(&snapshot, ethernet.is_some()).await?;
 
         // Keep the VPN modal's on/off state live while it's open.
         if let Some(modal) = &mut self.vpn {
@@ -395,19 +427,24 @@ Error: {}",
         // Refresh the always-on VPN badge.
         self.active_vpns = self.client.active_vpn_names(&snapshot);
 
-        // Refresh wired link status. Best-effort, and intentionally independent
-        // of the WiFi power state so it stays visible when the radio is off.
-        if let Ok(eth) = self.client.active_ethernet(&snapshot).await {
-            if let Some(station) = &mut self.device.station {
-                station.is_ethernet_connected = eth.is_some();
-            }
-            self.ethernet = eth;
-        }
+        // Wired status is tracked here rather than on the WiFi device so it
+        // stays visible when the radio is off.
+        self.set_ethernet(ethernet);
 
         // Refresh which link owns the default route (the live internet path).
         self.primary_link = self.client.primary_link(&snapshot);
 
         Ok(())
+    }
+
+    /// Records the active wired link, keeping the station's ethernet row in
+    /// step. `App` owns this because wired status stays meaningful while the
+    /// WiFi radio — and with it the station — is off.
+    fn set_ethernet(&mut self, ethernet: Option<EthernetInfo>) {
+        if let Some(station) = &mut self.device.station {
+            station.set_ethernet_connected(ethernet.is_some());
+        }
+        self.ethernet = ethernet;
     }
 
     pub fn quit(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -357,9 +357,16 @@ Error: {}",
         Ok(())
     }
 
-    pub async fn tick(&mut self) -> Result<()> {
+    /// Drops notifications past their deadline.
+    ///
+    /// Runs before every draw rather than on the refresh tick: a notification
+    /// can expire between ticks, and pruning only on the tick would paint it
+    /// past its lifetime on any redraw triggered by a keypress in between.
+    pub fn prune_expired_notifications(&mut self) {
         self.notifications.retain(|n| !n.is_expired());
+    }
 
+    pub async fn tick(&mut self) -> Result<()> {
         // One read of NetworkManager's object graph serves every refresh below,
         // so they all describe the same instant and cost one round trip between
         // them instead of one per object.

--- a/src/app.rs
+++ b/src/app.rs
@@ -381,7 +381,6 @@ Error: {}",
         }
 
         self.device.refresh().await?;
-        self.adapter.is_powered = self.device.is_powered;
 
         // Keep the VPN modal's on/off state live while it's open.
         if let Some(modal) = &mut self.vpn {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use toml;
 
 use dirs;
@@ -16,6 +18,12 @@ pub struct Config {
 
     #[serde(default = "default_vpn")]
     pub vpn: char,
+
+    /// How often to re-read NetworkManager state, in milliseconds. Raising this
+    /// trades how quickly changes made outside wlctl show up for less work per
+    /// second on machines with many saved profiles.
+    #[serde(default = "default_refresh_interval_ms")]
+    pub refresh_interval_ms: u64,
 
     #[serde(default)]
     pub device: Device,
@@ -42,6 +50,14 @@ fn default_esc_quit() -> bool {
 fn default_vpn() -> char {
     'v'
 }
+
+fn default_refresh_interval_ms() -> u64 {
+    1_000
+}
+
+/// Floor for [`Config::refresh_interval`]. A mistyped interval should slow the
+/// UI down, never turn it into a busy loop.
+const MIN_REFRESH_INTERVAL_MS: u64 = 250;
 
 // Device
 #[derive(Deserialize, Debug)]
@@ -196,6 +212,11 @@ fn default_ap_stop() -> char {
 }
 
 impl Config {
+    /// How often to re-read NetworkManager state.
+    pub fn refresh_interval(&self) -> Duration {
+        Duration::from_millis(self.refresh_interval_ms.max(MIN_REFRESH_INTERVAL_MS))
+    }
+
     pub fn new() -> Self {
         let conf_path = dirs::config_dir()
             .unwrap()

--- a/src/device.rs
+++ b/src/device.rs
@@ -31,7 +31,11 @@ pub struct Device {
 }
 
 impl Device {
-    pub async fn new(client: Arc<NMClient>, device_path: OwnedObjectPath) -> Result<Self> {
+    pub async fn new(
+        client: Arc<NMClient>,
+        device_path: OwnedObjectPath,
+        is_ethernet_connected: bool,
+    ) -> Result<Self> {
         let device_path_str = device_path.as_str().to_string();
 
         let name = client.get_device_interface(&device_path_str).await?;
@@ -45,7 +49,12 @@ impl Device {
         let (station, ap) = if is_powered {
             match mode {
                 Mode::Station => {
-                    if let Ok(station) = Station::new(client.clone(), device_path_str.clone()).await
+                    if let Ok(station) = Station::new(
+                        client.clone(),
+                        device_path_str.clone(),
+                        is_ethernet_connected,
+                    )
+                    .await
                     {
                         (Some(station), None)
                     } else {
@@ -77,7 +86,7 @@ impl Device {
         })
     }
 
-    pub async fn set_mode(&mut self, mode: Mode) -> Result<()> {
+    pub async fn set_mode(&mut self, mode: Mode, is_ethernet_connected: bool) -> Result<()> {
         // In NetworkManager, we don't switch modes explicitly
         // Instead, we activate different connection types
         // For AP mode, we'll create a hotspot connection
@@ -89,9 +98,13 @@ impl Device {
             Mode::Station => {
                 self.ap = None;
                 if self.is_powered {
-                    self.station = Station::new(self.client.clone(), self.device_path.clone())
-                        .await
-                        .ok();
+                    self.station = Station::new(
+                        self.client.clone(),
+                        self.device_path.clone(),
+                        is_ethernet_connected,
+                    )
+                    .await
+                    .ok();
                 }
             }
             Mode::Ap => {
@@ -117,7 +130,11 @@ impl Device {
         Ok(())
     }
 
-    pub async fn refresh(&mut self, snapshot: &NmSnapshot) -> Result<()> {
+    pub async fn refresh(
+        &mut self,
+        snapshot: &NmSnapshot,
+        is_ethernet_connected: bool,
+    ) -> Result<()> {
         self.is_powered = snapshot.wireless_enabled().unwrap_or(self.is_powered);
 
         if self.is_powered {
@@ -126,9 +143,13 @@ impl Device {
                     if let Some(station) = &mut self.station {
                         station.refresh(snapshot).await?;
                     } else {
-                        self.station = Station::new(self.client.clone(), self.device_path.clone())
-                            .await
-                            .ok();
+                        self.station = Station::new(
+                            self.client.clone(),
+                            self.device_path.clone(),
+                            is_ethernet_connected,
+                        )
+                        .await
+                        .ok();
                     }
                 }
                 Mode::Ap => {

--- a/src/device.rs
+++ b/src/device.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::sync::Arc;
 use zbus::zvariant::OwnedObjectPath;
 
-use crate::nm::{EthernetInfo, Mode, NMClient};
+use crate::nm::{EthernetInfo, Mode, NMClient, NmSnapshot};
 
 use ratatui::{
     Frame,
@@ -117,14 +117,14 @@ impl Device {
         Ok(())
     }
 
-    pub async fn refresh(&mut self) -> Result<()> {
-        self.is_powered = self.client.is_wireless_enabled().await?;
+    pub async fn refresh(&mut self, snapshot: &NmSnapshot) -> Result<()> {
+        self.is_powered = snapshot.wireless_enabled().unwrap_or(self.is_powered);
 
         if self.is_powered {
             match self.mode {
                 Mode::Station => {
                     if let Some(station) = &mut self.station {
-                        station.refresh().await?;
+                        station.refresh(snapshot).await?;
                     } else {
                         self.station = Station::new(self.client.clone(), self.device_path.clone())
                             .await

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,9 +1,4 @@
 use anyhow::Result;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
-use std::time::Duration;
 
 use crate::nm::Mode;
 use crossterm::event::{Event as CrosstermEvent, KeyEvent, MouseEvent};
@@ -37,41 +32,29 @@ pub enum Event {
     },
 }
 
+/// Forwards terminal input into the main loop.
+///
+/// Periodic refreshes are not produced here: the main loop drives them from its
+/// own timer so a refresh can never be queued while one is already running.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct EventHandler {
     pub sender: mpsc::UnboundedSender<Event>,
     pub receiver: mpsc::UnboundedReceiver<Event>,
     handler: tokio::task::JoinHandle<()>,
-    tick_pending: Arc<AtomicBool>,
 }
 
 impl EventHandler {
-    pub fn new(tick_rate: u64) -> Self {
-        let tick_rate = Duration::from_millis(tick_rate);
+    pub fn new() -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
         let sender_cloned = sender.clone();
-        let tick_pending = Arc::new(AtomicBool::new(false));
-        let tick_pending_cloned = tick_pending.clone();
         let handler = tokio::spawn(async move {
             let mut reader = crossterm::event::EventStream::new();
-            let mut tick = tokio::time::interval(tick_rate);
             loop {
-                let tick_delay = tick.tick();
                 let crossterm_event = reader.next().fuse();
                 tokio::select! {
                   () = sender_cloned.closed() => {
                     break;
-                  }
-                  _ = tick_delay => {
-                    // A refresh can take longer than the timer interval. Keep
-                    // at most one timer tick queued so the UI does not spend
-                    // its time catching up with stale refresh requests.
-                    if !tick_pending_cloned.swap(true, Ordering::AcqRel)
-                        && sender_cloned.send(Event::Tick).is_err()
-                    {
-                        break;
-                    }
                   }
                   Some(Ok(evt)) = crossterm_event => {
                     match evt {
@@ -98,20 +81,23 @@ impl EventHandler {
             sender,
             receiver,
             handler,
-            tick_pending,
         }
     }
 
+    /// Waits for the next terminal event.
+    ///
+    /// Cancel-safe: the underlying receive drops without losing a message, so
+    /// this can be raced against a timer in `select!`.
     pub async fn next(&mut self) -> Result<Event> {
         self.receiver
             .recv()
             .await
             .ok_or(std::io::Error::other("This is an IO error").into())
     }
+}
 
-    /// Allow the timer to enqueue another refresh after the current one has
-    /// fully completed.
-    pub fn mark_tick_handled(&self) {
-        self.tick_pending.store(false, Ordering::Release);
+impl Default for EventHandler {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,8 @@
 use anyhow::Result;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Duration;
 
 use crate::nm::Mode;
@@ -39,6 +43,7 @@ pub struct EventHandler {
     pub sender: mpsc::UnboundedSender<Event>,
     pub receiver: mpsc::UnboundedReceiver<Event>,
     handler: tokio::task::JoinHandle<()>,
+    tick_pending: Arc<AtomicBool>,
 }
 
 impl EventHandler {
@@ -46,6 +51,8 @@ impl EventHandler {
         let tick_rate = Duration::from_millis(tick_rate);
         let (sender, receiver) = mpsc::unbounded_channel();
         let sender_cloned = sender.clone();
+        let tick_pending = Arc::new(AtomicBool::new(false));
+        let tick_pending_cloned = tick_pending.clone();
         let handler = tokio::spawn(async move {
             let mut reader = crossterm::event::EventStream::new();
             let mut tick = tokio::time::interval(tick_rate);
@@ -57,7 +64,14 @@ impl EventHandler {
                     break;
                   }
                   _ = tick_delay => {
-                    sender_cloned.send(Event::Tick).unwrap();
+                    // A refresh can take longer than the timer interval. Keep
+                    // at most one timer tick queued so the UI does not spend
+                    // its time catching up with stale refresh requests.
+                    if !tick_pending_cloned.swap(true, Ordering::AcqRel)
+                        && sender_cloned.send(Event::Tick).is_err()
+                    {
+                        break;
+                    }
                   }
                   Some(Ok(evt)) = crossterm_event => {
                     match evt {
@@ -84,6 +98,7 @@ impl EventHandler {
             sender,
             receiver,
             handler,
+            tick_pending,
         }
     }
 
@@ -92,5 +107,11 @@ impl EventHandler {
             .recv()
             .await
             .ok_or(std::io::Error::other("This is an IO error").into())
+    }
+
+    /// Allow the timer to enqueue another refresh after the current one has
+    /// fully completed.
+    pub fn mark_tick_handled(&self) {
+        self.tick_pending.store(false, Ordering::Release);
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -968,7 +968,7 @@ pub async fn handle_key_events(
                                         {
                                             // Only run speed test if connected
                                             if station.connected_network.is_some()
-                                                || station.is_ethernet_connected
+                                                || station.is_ethernet_connected()
                                             {
                                                 // Show loading popup
                                                 station.speed_test = Some(SpeedTest::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
     let backend = CrosstermBackend::new(io::stdout());
     let terminal = Terminal::new(backend)?;
-    let events = EventHandler::new(1_000);
+    let events = EventHandler::new(3_000);
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ use anyhow::anyhow;
 use env_logger::Target;
 use ratatui::{Terminal, backend::CrosstermBackend};
 use std::sync::Arc;
+use std::time::Duration;
 use std::{io, process::exit};
+use tokio::time::{Instant, MissedTickBehavior, interval_at};
 use wlctl::{
     app::App,
     cli,
@@ -36,7 +38,7 @@ async fn main() -> Result<()> {
 
     let backend = CrosstermBackend::new(io::stdout());
     let terminal = Terminal::new(backend)?;
-    let events = EventHandler::new(3_000);
+    let events = EventHandler::new();
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
 
@@ -70,6 +72,14 @@ async fn main() -> Result<()> {
     // to the VPN import field so pastes elsewhere keep their default behavior.
     let mut bracketed_paste = false;
 
+    // Driving the refresh timer from this loop — rather than from a task
+    // feeding the event channel — means a refresh cannot be queued while one is
+    // already running, so a slow refresh simply delays the next one instead of
+    // building a backlog the UI then has to work through.
+    let refresh_interval = Duration::from_millis(3_000);
+    let mut refresh = interval_at(Instant::now() + refresh_interval, refresh_interval);
+    refresh.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
     while app.running {
         tui.draw(&mut app)?;
 
@@ -83,11 +93,14 @@ async fn main() -> Result<()> {
             bracketed_paste = want_paste;
         }
 
-        match tui.events.next().await? {
+        let event = tokio::select! {
+            _ = refresh.tick() => Event::Tick,
+            received = tui.events.next() => received?,
+        };
+
+        match event {
             Event::Tick => {
-                let result = app.tick().await;
-                tui.events.mark_tick_handled();
-                if let Err(e) = result {
+                if let Err(e) = app.tick().await {
                     exit_error_message = Some(e);
                     break;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,9 @@ async fn main() -> Result<()> {
 
         match tui.events.next().await? {
             Event::Tick => {
-                if let Err(e) = app.tick().await {
+                let result = app.tick().await;
+                tui.events.mark_tick_handled();
+                if let Err(e) = result {
                     exit_error_message = Some(e);
                     break;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use anyhow::anyhow;
 use env_logger::Target;
 use ratatui::{Terminal, backend::CrosstermBackend};
 use std::sync::Arc;
-use std::time::Duration;
 use std::{io, process::exit};
 use tokio::time::{Instant, MissedTickBehavior, interval_at};
 use wlctl::{
@@ -76,7 +75,7 @@ async fn main() -> Result<()> {
     // feeding the event channel — means a refresh cannot be queued while one is
     // already running, so a slow refresh simply delays the next one instead of
     // building a backlog the UI then has to work through.
-    let refresh_interval = Duration::from_millis(3_000);
+    let refresh_interval = config.refresh_interval();
     let mut refresh = interval_at(Instant::now() + refresh_interval, refresh_interval);
     refresh.set_missed_tick_behavior(MissedTickBehavior::Delay);
 

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -110,7 +110,10 @@ pub struct Station {
     pub state: StationState,
     pub is_scanning: bool,
     pub connected_network: Option<Network>,
-    pub is_ethernet_connected: bool,
+    /// Whether a wired link is up. Owned by `App`, which tracks ethernet
+    /// independently of the WiFi radio so the row stays correct with the radio
+    /// off; the station only renders it and offsets its table rows by it.
+    is_ethernet_connected: bool,
     pub new_networks: Vec<(Network, i16)>,
     pub new_hidden_networks: Vec<HiddenNetwork>,
     pub known_networks: Vec<(Network, i16)>,
@@ -136,7 +139,11 @@ pub struct Station {
 }
 
 impl Station {
-    pub async fn new(client: Arc<NMClient>, device_path: String) -> Result<Self> {
+    pub async fn new(
+        client: Arc<NMClient>,
+        device_path: String,
+        is_ethernet_connected: bool,
+    ) -> Result<Self> {
         let device_state = client.get_device_state(&device_path).await?;
         let state = StationState::from(device_state);
 
@@ -146,10 +153,6 @@ impl Station {
         let _ = client.request_scan(&device_path).await;
 
         let snapshot = NmSnapshot::fetch(&client).await?;
-        let is_ethernet_connected = client
-            .has_active_ethernet_connection(&snapshot)
-            .await
-            .unwrap_or(false);
         let visible_networks = snapshot.visible_networks(&device_path);
         let saved_connections = client.wifi_connections(&snapshot).await?;
         let active_ap = snapshot.active_access_point(&device_path);
@@ -199,6 +202,17 @@ impl Station {
             filter_input: false,
             visible_new,
         })
+    }
+
+    /// Whether a wired link is currently up.
+    pub fn is_ethernet_connected(&self) -> bool {
+        self.is_ethernet_connected
+    }
+
+    /// Records wired-link presence. `App` resolves this once per refresh and
+    /// pushes it down, so the station never queries it a second time.
+    pub fn set_ethernet_connected(&mut self, connected: bool) {
+        self.is_ethernet_connected = connected;
     }
 
     /// Reads the active adapter's primary IPv4, if any. Best-effort: a missing

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -144,15 +144,22 @@ impl Station {
             .await
             .unwrap_or(false);
 
-        let connected_ssid = client.get_connected_ssid(&device_path).await?;
+        let active_ap_path = client.get_active_access_point(&device_path).await?;
 
         // Request a fresh scan so we get up-to-date AP data.
         // This is non-blocking; NM populates APs asynchronously and
         // the periodic refresh() tick will pick them up.
         let _ = client.request_scan(&device_path).await;
 
-        let visible_networks = client.get_visible_networks(&device_path).await?;
-        let saved_connections = client.get_wifi_connections().await?;
+        let managed = client.get_managed_objects().await?;
+        let visible_networks = client
+            .get_visible_networks_from_managed(&device_path, &managed)
+            .await?;
+        let saved_connections = client.get_wifi_connections_from_managed(&managed).await?;
+        let active_ap = active_ap_path
+            .as_ref()
+            .and_then(|path| client.get_access_point_info_from_managed(path, &managed));
+        let connected_ssid = active_ap.as_ref().map(|ap| ap.ssid.clone());
 
         let (new_networks, known_networks, connected_network) = Self::categorize_networks(
             &client,
@@ -165,8 +172,10 @@ impl Station {
         let unavailable_known_networks =
             Self::find_unavailable_networks(&client, &known_networks, saved_connections);
 
-        let diagnostic =
-            Self::fetch_diagnostic(&client, &device_path, connected_network.is_some()).await?;
+        let diagnostic = connected_network
+            .as_ref()
+            .and(active_ap.as_ref())
+            .map(Self::diagnostic_from_access_point);
 
         let ipv4 = Self::fetch_device_ipv4(&client, &device_path).await;
 
@@ -213,15 +222,24 @@ impl Station {
         let device_state = self.client.get_device_state(&self.device_path).await?;
         self.state = StationState::from(device_state);
 
-        self.is_ethernet_connected = self
+        let active_ap_path = self
             .client
-            .has_active_ethernet_connection()
-            .await
-            .unwrap_or(false);
-
-        let connected_ssid = self.client.get_connected_ssid(&self.device_path).await?;
-        let visible_networks = self.client.get_visible_networks(&self.device_path).await?;
-        let saved_connections = self.client.get_wifi_connections().await?;
+            .get_active_access_point(&self.device_path)
+            .await?;
+        let managed = self.client.get_managed_objects().await?;
+        let visible_networks = self
+            .client
+            .get_visible_networks_from_managed(&self.device_path, &managed)
+            .await?;
+        let saved_connections = self
+            .client
+            .get_wifi_connections_from_managed(&managed)
+            .await?;
+        let active_ap = active_ap_path.as_ref().and_then(|path| {
+            self.client
+                .get_access_point_info_from_managed(path, &managed)
+        });
+        let connected_ssid = active_ap.as_ref().map(|ap| ap.ssid.clone());
 
         let (new_networks, known_networks, connected_network) = Self::categorize_networks(
             &self.client,
@@ -245,12 +263,11 @@ impl Station {
             Self::find_unavailable_networks(&self.client, &self.known_networks, saved_connections);
 
         self.connected_network = connected_network;
-        self.diagnostic = Self::fetch_diagnostic(
-            &self.client,
-            &self.device_path,
-            self.connected_network.is_some(),
-        )
-        .await?;
+        self.diagnostic = self
+            .connected_network
+            .as_ref()
+            .and(active_ap.as_ref())
+            .map(Self::diagnostic_from_access_point);
 
         self.ipv4 = Self::fetch_device_ipv4(&self.client, &self.device_path).await;
 
@@ -319,26 +336,15 @@ impl Station {
             .collect()
     }
 
-    /// Fetch diagnostic info for the active access point.
-    async fn fetch_diagnostic(
-        client: &NMClient,
-        device_path: &str,
-        is_connected: bool,
-    ) -> Result<Option<DiagnosticInfo>> {
-        if !is_connected {
-            return Ok(None);
+    /// Build diagnostic data from the active AP already present in the shared
+    /// ObjectManager snapshot.
+    fn diagnostic_from_access_point(ap_info: &AccessPointInfo) -> DiagnosticInfo {
+        DiagnosticInfo {
+            frequency: Some(ap_info.frequency),
+            signal_strength: Some(ap_info.strength as i32),
+            security: Some(ap_info.security.to_string()),
+            ..Default::default()
         }
-        if let Some(ap_path) = client.get_active_access_point(device_path).await?
-            && let Ok(ap_info) = client.get_access_point_info(ap_path.as_str()).await
-        {
-            return Ok(Some(DiagnosticInfo {
-                frequency: Some(ap_info.frequency),
-                signal_strength: Some(ap_info.strength as i32),
-                security: Some(ap_info.security.to_string()),
-                ..Default::default()
-            }));
-        }
-        Ok(None)
     }
 
     /// Create a TableState with the first item selected if the list is non-empty.

--- a/src/mode/station.rs
+++ b/src/mode/station.rs
@@ -8,7 +8,8 @@ pub mod speed_test;
 use std::sync::Arc;
 
 use crate::nm::{
-    AccessPointInfo, ConnectionInfo, DiagnosticInfo, LinkKind, NMClient, PrimaryLink, StationState,
+    AccessPointInfo, ConnectionInfo, DiagnosticInfo, LinkKind, NMClient, NmSnapshot, PrimaryLink,
+    StationState,
 };
 use ratatui::{
     Frame,
@@ -139,26 +140,19 @@ impl Station {
         let device_state = client.get_device_state(&device_path).await?;
         let state = StationState::from(device_state);
 
-        let is_ethernet_connected = client
-            .has_active_ethernet_connection()
-            .await
-            .unwrap_or(false);
-
-        let active_ap_path = client.get_active_access_point(&device_path).await?;
-
         // Request a fresh scan so we get up-to-date AP data.
         // This is non-blocking; NM populates APs asynchronously and
         // the periodic refresh() tick will pick them up.
         let _ = client.request_scan(&device_path).await;
 
-        let managed = client.get_managed_objects().await?;
-        let visible_networks = client
-            .get_visible_networks_from_managed(&device_path, &managed)
-            .await?;
-        let saved_connections = client.get_wifi_connections_from_managed(&managed).await?;
-        let active_ap = active_ap_path
-            .as_ref()
-            .and_then(|path| client.get_access_point_info_from_managed(path, &managed));
+        let snapshot = NmSnapshot::fetch(&client).await?;
+        let is_ethernet_connected = client
+            .has_active_ethernet_connection(&snapshot)
+            .await
+            .unwrap_or(false);
+        let visible_networks = snapshot.visible_networks(&device_path);
+        let saved_connections = client.wifi_connections(&snapshot).await?;
+        let active_ap = snapshot.active_access_point(&device_path);
         let connected_ssid = active_ap.as_ref().map(|ap| ap.ssid.clone());
 
         let (new_networks, known_networks, connected_network) = Self::categorize_networks(
@@ -170,11 +164,11 @@ impl Station {
         );
 
         let unavailable_known_networks =
-            Self::find_unavailable_networks(&client, &known_networks, saved_connections);
+            Self::find_unavailable_networks(&client, &known_networks, &saved_connections);
 
-        let diagnostic = connected_network
+        let diagnostic = active_ap
             .as_ref()
-            .and(active_ap.as_ref())
+            .filter(|_| connected_network.is_some())
             .map(Self::diagnostic_from_access_point);
 
         let ipv4 = Self::fetch_device_ipv4(&client, &device_path).await;
@@ -218,27 +212,14 @@ impl Station {
             .and_then(|ip| ip.addresses.into_iter().next().map(|(addr, _)| addr))
     }
 
-    pub async fn refresh(&mut self) -> Result<()> {
-        let device_state = self.client.get_device_state(&self.device_path).await?;
-        self.state = StationState::from(device_state);
+    pub async fn refresh(&mut self, snapshot: &NmSnapshot) -> Result<()> {
+        if let Some(device_state) = snapshot.device_state(&self.device_path) {
+            self.state = StationState::from(device_state);
+        }
 
-        let active_ap_path = self
-            .client
-            .get_active_access_point(&self.device_path)
-            .await?;
-        let managed = self.client.get_managed_objects().await?;
-        let visible_networks = self
-            .client
-            .get_visible_networks_from_managed(&self.device_path, &managed)
-            .await?;
-        let saved_connections = self
-            .client
-            .get_wifi_connections_from_managed(&managed)
-            .await?;
-        let active_ap = active_ap_path.as_ref().and_then(|path| {
-            self.client
-                .get_access_point_info_from_managed(path, &managed)
-        });
+        let visible_networks = snapshot.visible_networks(&self.device_path);
+        let saved_connections = self.client.wifi_connections(snapshot).await?;
+        let active_ap = snapshot.active_access_point(&self.device_path);
         let connected_ssid = active_ap.as_ref().map(|ap| ap.ssid.clone());
 
         let (new_networks, known_networks, connected_network) = Self::categorize_networks(
@@ -260,13 +241,12 @@ impl Station {
         self.update_known_network_list(&known_networks);
 
         self.unavailable_known_networks =
-            Self::find_unavailable_networks(&self.client, &self.known_networks, saved_connections);
+            Self::find_unavailable_networks(&self.client, &self.known_networks, &saved_connections);
 
         self.connected_network = connected_network;
-        self.diagnostic = self
-            .connected_network
+        self.diagnostic = active_ap
             .as_ref()
-            .and(active_ap.as_ref())
+            .filter(|_| self.connected_network.is_some())
             .map(Self::diagnostic_from_access_point);
 
         self.ipv4 = Self::fetch_device_ipv4(&self.client, &self.device_path).await;
@@ -322,7 +302,7 @@ impl Station {
     fn find_unavailable_networks(
         client: &Arc<NMClient>,
         known_networks: &[(Network, i16)],
-        saved_connections: Vec<ConnectionInfo>,
+        saved_connections: &[ConnectionInfo],
     ) -> Vec<KnownNetwork> {
         let visible_ssids: Vec<&str> = known_networks
             .iter()
@@ -330,9 +310,9 @@ impl Station {
             .collect();
 
         saved_connections
-            .into_iter()
+            .iter()
             .filter(|conn| !visible_ssids.contains(&conn.ssid.as_str()))
-            .map(|conn| KnownNetwork::from_connection_info(client.clone(), conn))
+            .map(|conn| KnownNetwork::from_connection_info(client.clone(), conn.clone()))
             .collect()
     }
 

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -4,6 +4,7 @@
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
 use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 use zbus::{Connection, Proxy};
 
@@ -72,10 +73,21 @@ fn ipv6_dns_bytes(dns: &[IpAddr]) -> Vec<Vec<u8>> {
         .collect()
 }
 
+/// Saved wifi connections plus the `(path, VersionId)` fingerprint they were
+/// built from. When the fingerprint is unchanged, the list is reused instead of
+/// re-reading every connection's settings.
+#[derive(Debug)]
+struct WifiConnCache {
+    fingerprint: Vec<(String, u64)>,
+    connections: Vec<ConnectionInfo>,
+}
+
 /// Main NetworkManager client
 #[derive(Clone, Debug)]
 pub struct NMClient {
     connection: Connection,
+    // Shared across clones so the cache is process-wide.
+    wifi_conn_cache: Arc<Mutex<Option<WifiConnCache>>>,
 }
 
 impl NMClient {
@@ -99,7 +111,10 @@ impl NMClient {
             "NetworkManager is not running or not accessible. Please ensure NetworkManager service is active.",
         )?;
 
-        Ok(Self { connection })
+        Ok(Self {
+            connection,
+            wifi_conn_cache: Arc::new(Mutex::new(None)),
+        })
     }
 
     /// Get the D-Bus connection
@@ -482,6 +497,43 @@ impl NMClient {
     /// Get WiFi connection profiles
     #[allow(clippy::collapsible_if, clippy::map_flatten)]
     pub async fn get_wifi_connections(&self) -> Result<Vec<ConnectionInfo>> {
+        let managed = self.get_managed_objects().await?;
+        self.get_wifi_connections_from_managed(&managed).await
+    }
+
+    /// Get WiFi connection profiles using an existing ObjectManager snapshot.
+    #[allow(clippy::collapsible_if, clippy::map_flatten)]
+    pub async fn get_wifi_connections_from_managed(
+        &self,
+        managed: &ManagedObjects,
+    ) -> Result<Vec<ConnectionInfo>> {
+        // Reading GetSettings for every saved connection on each refresh is the
+        // dominant per-tick cost when many profiles exist. Saved connections
+        // change rarely, so fingerprint them by (path, VersionId) -- both come
+        // free from the ObjectManager payload -- and rebuild only on change.
+        const CONN_IFACE: &str = "org.freedesktop.NetworkManager.Settings.Connection";
+        let mut fingerprint: Vec<(String, u64)> = managed
+            .iter()
+            .filter_map(|(path, ifaces)| {
+                let props = ifaces.get(CONN_IFACE)?;
+                let version = props
+                    .get("VersionId")
+                    .and_then(|v| v.try_clone().ok())
+                    .and_then(|v| u64::try_from(v).ok())
+                    .unwrap_or(0);
+                Some((path.as_str().to_string(), version))
+            })
+            .collect();
+        fingerprint.sort();
+
+        // Cache hit: nothing added, removed, or edited since last time.
+        if let Ok(guard) = self.wifi_conn_cache.lock()
+            && let Some(cache) = guard.as_ref()
+            && cache.fingerprint == fingerprint
+        {
+            return Ok(cache.connections.clone());
+        }
+
         let connections = self.get_connections().await?;
         let mut wifi_connections = Vec::new();
 
@@ -575,6 +627,13 @@ impl NMClient {
 
         // Sort by timestamp (most recent first)
         wifi_connections.sort_by_key(|c| std::cmp::Reverse(c.timestamp));
+
+        if let Ok(mut guard) = self.wifi_conn_cache.lock() {
+            *guard = Some(WifiConnCache {
+                fingerprint,
+                connections: wifi_connections.clone(),
+            });
+        }
 
         Ok(wifi_connections)
     }

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -13,6 +13,8 @@ pub mod wifi;
 
 pub use types::*;
 
+pub type ManagedObjects = HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>>;
+
 const NM_BUS_NAME: &str = "org.freedesktop.NetworkManager";
 const NM_PATH: &str = "/org/freedesktop/NetworkManager";
 
@@ -338,37 +340,81 @@ impl NMClient {
         }
     }
 
-    /// Get access point details
-    pub async fn get_access_point_info(&self, ap_path: &str) -> Result<AccessPointInfo> {
-        let proxy = Proxy::new(
-            &self.connection,
-            NM_BUS_NAME,
-            ap_path,
-            "org.freedesktop.NetworkManager.AccessPoint",
-        )
-        .await?;
+    /// Build an `AccessPointInfo` from an AccessPoint interface's property map,
+    /// as returned by either `Properties.GetAll` or `ObjectManager`.
+    fn access_point_info_from_props(
+        ap_path: &str,
+        props: &HashMap<String, OwnedValue>,
+    ) -> AccessPointInfo {
+        let u32_of = |key: &str| -> u32 {
+            props
+                .get(key)
+                .and_then(|v| v.try_clone().ok())
+                .and_then(|v| u32::try_from(v).ok())
+                .unwrap_or(0)
+        };
 
-        let ssid_bytes: Vec<u8> = proxy.get_property("Ssid").await?;
+        let ssid_bytes: Vec<u8> = props
+            .get("Ssid")
+            .and_then(|v| v.try_clone().ok())
+            .and_then(|v| Vec::<u8>::try_from(v).ok())
+            .unwrap_or_default();
         let ssid = String::from_utf8_lossy(&ssid_bytes).to_string();
-        let strength: u8 = proxy.get_property("Strength").await?;
-        let frequency: u32 = proxy.get_property("Frequency").await?;
-        let hw_address: String = proxy.get_property("HwAddress").await?;
-        let flags: u32 = proxy.get_property("Flags").await?;
-        let wpa_flags: u32 = proxy.get_property("WpaFlags").await?;
-        let rsn_flags: u32 = proxy.get_property("RsnFlags").await?;
-        let mode: u32 = proxy.get_property("Mode").await?;
+        let strength: u8 = props
+            .get("Strength")
+            .and_then(|v| v.try_clone().ok())
+            .and_then(|v| u8::try_from(v).ok())
+            .unwrap_or(0);
+        let hw_address: String = props
+            .get("HwAddress")
+            .and_then(|v| v.try_clone().ok())
+            .and_then(|v| String::try_from(v).ok())
+            .unwrap_or_default();
+        let flags = u32_of("Flags");
+        let wpa_flags = u32_of("WpaFlags");
+        let rsn_flags = u32_of("RsnFlags");
 
-        let security = SecurityType::from_flags(flags, wpa_flags, rsn_flags);
-
-        Ok(AccessPointInfo {
+        AccessPointInfo {
             path: ap_path.to_string(),
             ssid,
             strength,
-            frequency,
+            frequency: u32_of("Frequency"),
             hw_address,
-            security,
-            mode: WifiMode::from(mode),
-        })
+            security: SecurityType::from_flags(flags, wpa_flags, rsn_flags),
+            mode: WifiMode::from(u32_of("Mode")),
+        }
+    }
+
+    /// Get access point details via a single `Properties.GetAll`.
+    pub async fn get_access_point_info(&self, ap_path: &str) -> Result<AccessPointInfo> {
+        let props = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            ap_path,
+            "org.freedesktop.DBus.Properties",
+        )
+        .await?;
+
+        let all: HashMap<String, OwnedValue> = props
+            .call("GetAll", &("org.freedesktop.NetworkManager.AccessPoint",))
+            .await?;
+
+        Ok(Self::access_point_info_from_props(ap_path, &all))
+    }
+
+    /// Fetch every managed NM object with all its interface properties in one
+    /// ObjectManager round-trip. Used to enumerate all visible APs at once
+    /// instead of a `GetAll` per AP.
+    pub async fn get_managed_objects(&self) -> Result<ManagedObjects> {
+        let proxy = Proxy::new(
+            &self.connection,
+            NM_BUS_NAME,
+            "/org/freedesktop",
+            "org.freedesktop.DBus.ObjectManager",
+        )
+        .await?;
+
+        Ok(proxy.call("GetManagedObjects", &()).await?)
     }
 
     /// Get all saved connections

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -4,17 +4,17 @@
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::net::IpAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 use zbus::{Connection, Proxy};
 
 pub mod dbus_interfaces;
+pub mod snapshot;
 pub mod types;
 pub mod wifi;
 
+pub use snapshot::NmSnapshot;
 pub use types::*;
-
-pub type ManagedObjects = HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>>;
 
 const NM_BUS_NAME: &str = "org.freedesktop.NetworkManager";
 const NM_PATH: &str = "/org/freedesktop/NetworkManager";
@@ -73,13 +73,13 @@ fn ipv6_dns_bytes(dns: &[IpAddr]) -> Vec<Vec<u8>> {
         .collect()
 }
 
-/// Saved wifi connections plus the `(path, VersionId)` fingerprint they were
-/// built from. When the fingerprint is unchanged, the list is reused instead of
-/// re-reading every connection's settings.
+/// Saved WiFi profiles together with the `(path, VersionId)` list they were
+/// built from, so an unchanged list can be served without re-reading every
+/// profile's settings.
 #[derive(Debug)]
-struct WifiConnCache {
-    fingerprint: Vec<(String, u64)>,
-    connections: Vec<ConnectionInfo>,
+struct WifiConnectionCache {
+    versions: Vec<(String, Option<u64>)>,
+    connections: Arc<[ConnectionInfo]>,
 }
 
 /// Main NetworkManager client
@@ -87,7 +87,7 @@ struct WifiConnCache {
 pub struct NMClient {
     connection: Connection,
     // Shared across clones so the cache is process-wide.
-    wifi_conn_cache: Arc<Mutex<Option<WifiConnCache>>>,
+    wifi_connection_cache: Arc<Mutex<Option<WifiConnectionCache>>>,
 }
 
 impl NMClient {
@@ -113,7 +113,7 @@ impl NMClient {
 
         Ok(Self {
             connection,
-            wifi_conn_cache: Arc::new(Mutex::new(None)),
+            wifi_connection_cache: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -355,52 +355,10 @@ impl NMClient {
         }
     }
 
-    /// Build an `AccessPointInfo` from an AccessPoint interface's property map,
-    /// as returned by either `Properties.GetAll` or `ObjectManager`.
-    fn access_point_info_from_props(
-        ap_path: &str,
-        props: &HashMap<String, OwnedValue>,
-    ) -> AccessPointInfo {
-        let u32_of = |key: &str| -> u32 {
-            props
-                .get(key)
-                .and_then(|v| v.try_clone().ok())
-                .and_then(|v| u32::try_from(v).ok())
-                .unwrap_or(0)
-        };
-
-        let ssid_bytes: Vec<u8> = props
-            .get("Ssid")
-            .and_then(|v| v.try_clone().ok())
-            .and_then(|v| Vec::<u8>::try_from(v).ok())
-            .unwrap_or_default();
-        let ssid = String::from_utf8_lossy(&ssid_bytes).to_string();
-        let strength: u8 = props
-            .get("Strength")
-            .and_then(|v| v.try_clone().ok())
-            .and_then(|v| u8::try_from(v).ok())
-            .unwrap_or(0);
-        let hw_address: String = props
-            .get("HwAddress")
-            .and_then(|v| v.try_clone().ok())
-            .and_then(|v| String::try_from(v).ok())
-            .unwrap_or_default();
-        let flags = u32_of("Flags");
-        let wpa_flags = u32_of("WpaFlags");
-        let rsn_flags = u32_of("RsnFlags");
-
-        AccessPointInfo {
-            path: ap_path.to_string(),
-            ssid,
-            strength,
-            frequency: u32_of("Frequency"),
-            hw_address,
-            security: SecurityType::from_flags(flags, wpa_flags, rsn_flags),
-            mode: WifiMode::from(u32_of("Mode")),
-        }
-    }
-
     /// Get access point details via a single `Properties.GetAll`.
+    ///
+    /// Prefer reading from an [`NmSnapshot`] when more than one object is
+    /// needed; this exists for callers that hold a single path.
     pub async fn get_access_point_info(&self, ap_path: &str) -> Result<AccessPointInfo> {
         let props = Proxy::new(
             &self.connection,
@@ -411,25 +369,10 @@ impl NMClient {
         .await?;
 
         let all: HashMap<String, OwnedValue> = props
-            .call("GetAll", &("org.freedesktop.NetworkManager.AccessPoint",))
+            .call("GetAll", &(snapshot::interface::ACCESS_POINT,))
             .await?;
 
-        Ok(Self::access_point_info_from_props(ap_path, &all))
-    }
-
-    /// Fetch every managed NM object with all its interface properties in one
-    /// ObjectManager round-trip. Used to enumerate all visible APs at once
-    /// instead of a `GetAll` per AP.
-    pub async fn get_managed_objects(&self) -> Result<ManagedObjects> {
-        let proxy = Proxy::new(
-            &self.connection,
-            NM_BUS_NAME,
-            "/org/freedesktop",
-            "org.freedesktop.DBus.ObjectManager",
-        )
-        .await?;
-
-        Ok(proxy.call("GetManagedObjects", &()).await?)
+        Ok(snapshot::access_point_info(ap_path, &all))
     }
 
     /// Get all saved connections
@@ -494,148 +437,115 @@ impl NMClient {
         Ok(None)
     }
 
-    /// Get WiFi connection profiles
-    #[allow(clippy::collapsible_if, clippy::map_flatten)]
-    pub async fn get_wifi_connections(&self) -> Result<Vec<ConnectionInfo>> {
-        let managed = self.get_managed_objects().await?;
-        self.get_wifi_connections_from_managed(&managed).await
+    /// Get WiFi connection profiles, reading the object graph once.
+    pub async fn get_wifi_connections(&self) -> Result<Arc<[ConnectionInfo]>> {
+        let snapshot = NmSnapshot::fetch(self).await?;
+        self.wifi_connections(&snapshot).await
     }
 
-    /// Get WiFi connection profiles using an existing ObjectManager snapshot.
-    #[allow(clippy::collapsible_if, clippy::map_flatten)]
-    pub async fn get_wifi_connections_from_managed(
-        &self,
-        managed: &ManagedObjects,
-    ) -> Result<Vec<ConnectionInfo>> {
-        // Reading GetSettings for every saved connection on each refresh is the
-        // dominant per-tick cost when many profiles exist. Saved connections
-        // change rarely, so fingerprint them by (path, VersionId) -- both come
-        // free from the ObjectManager payload -- and rebuild only on change.
-        const CONN_IFACE: &str = "org.freedesktop.NetworkManager.Settings.Connection";
-        let mut fingerprint: Vec<(String, u64)> = managed
-            .iter()
-            .filter_map(|(path, ifaces)| {
-                let props = ifaces.get(CONN_IFACE)?;
-                let version = props
-                    .get("VersionId")
-                    .and_then(|v| v.try_clone().ok())
-                    .and_then(|v| u64::try_from(v).ok())
-                    .unwrap_or(0);
-                Some((path.as_str().to_string(), version))
-            })
-            .collect();
-        fingerprint.sort();
-
-        // Cache hit: nothing added, removed, or edited since last time.
-        if let Ok(guard) = self.wifi_conn_cache.lock()
-            && let Some(cache) = guard.as_ref()
-            && cache.fingerprint == fingerprint
-        {
-            return Ok(cache.connections.clone());
+    /// Get the WiFi connection profiles described by `snapshot`.
+    ///
+    /// `GetSettings` costs a round trip per saved profile and dominates a
+    /// refresh once a machine has accumulated a few hundred of them. Profiles
+    /// change rarely, so the previous result is reused until `snapshot` reports
+    /// one added, removed, or edited.
+    pub async fn wifi_connections(&self, snapshot: &NmSnapshot) -> Result<Arc<[ConnectionInfo]>> {
+        let versions = snapshot.connection_versions();
+        if let Some(cached) = self.cached_wifi_connections(&versions) {
+            return Ok(cached);
         }
 
-        let connections = self.get_connections().await?;
         let mut wifi_connections = Vec::new();
-
-        for conn_path in connections {
-            if let Ok(settings) = self.get_connection_settings(conn_path.as_str()).await {
-                if let Some(connection_settings) = settings.get("connection") {
-                    if let Some(conn_type) = connection_settings.get("type") {
-                        let type_str: String = conn_type.try_clone()?.try_into()?;
-                        if type_str == "802-11-wireless" {
-                            let id: String = connection_settings
-                                .get("id")
-                                .map(|v| v.try_clone().ok().and_then(|v| v.try_into().ok()))
-                                .flatten()
-                                .unwrap_or_default();
-
-                            let uuid: String = connection_settings
-                                .get("uuid")
-                                .map(|v| v.try_clone().ok().and_then(|v| v.try_into().ok()))
-                                .flatten()
-                                .unwrap_or_default();
-
-                            let autoconnect: bool = connection_settings
-                                .get("autoconnect")
-                                .map(|v| v.try_clone().ok().and_then(|v| v.try_into().ok()))
-                                .flatten()
-                                .unwrap_or(true);
-
-                            let timestamp: u64 = connection_settings
-                                .get("timestamp")
-                                .map(|v| v.try_clone().ok().and_then(|v| v.try_into().ok()))
-                                .flatten()
-                                .unwrap_or(0);
-
-                            // Get SSID from wireless settings
-                            let ssid =
-                                if let Some(wireless_settings) = settings.get("802-11-wireless") {
-                                    wireless_settings
-                                        .get("ssid")
-                                        .map(|v| {
-                                            v.try_clone().ok().and_then(|v| {
-                                                let bytes: Result<Vec<u8>, _> = v.try_into();
-                                                bytes.ok().map(|b| {
-                                                    String::from_utf8_lossy(&b).to_string()
-                                                })
-                                            })
-                                        })
-                                        .flatten()
-                                        .unwrap_or(id.clone())
-                                } else {
-                                    id.clone()
-                                };
-
-                            // Check if it's a hidden network
-                            let hidden =
-                                if let Some(wireless_settings) = settings.get("802-11-wireless") {
-                                    wireless_settings
-                                        .get("hidden")
-                                        .map(|v| v.try_clone().ok().and_then(|v| v.try_into().ok()))
-                                        .flatten()
-                                        .unwrap_or(false)
-                                } else {
-                                    false
-                                };
-
-                            // Get security type from wireless-security settings
-                            let security = if settings.contains_key("802-11-wireless-security") {
-                                if settings.contains_key("802-1x") {
-                                    SecurityType::Enterprise
-                                } else {
-                                    SecurityType::WPA
-                                }
-                            } else {
-                                SecurityType::Open
-                            };
-
-                            wifi_connections.push(ConnectionInfo {
-                                path: conn_path.to_string(),
-                                id,
-                                uuid,
-                                ssid,
-                                autoconnect,
-                                timestamp,
-                                hidden,
-                                security,
-                            });
-                        }
-                    }
-                }
+        for (path, _) in &versions {
+            let Ok(settings) = self.get_connection_settings(path).await else {
+                continue;
+            };
+            let Some(connection) = settings.get("connection") else {
+                continue;
+            };
+            if setting_str(connection, "type").as_deref() != Some("802-11-wireless") {
+                continue;
             }
+
+            let id = setting_str(connection, "id").unwrap_or_default();
+            let wireless = settings.get("802-11-wireless");
+            // NetworkManager stores the SSID as raw bytes; the profile name is
+            // the best stand-in when it is absent.
+            let ssid = wireless
+                .and_then(|w| w.get("ssid"))
+                .and_then(|v| v.try_clone().ok())
+                .and_then(|v| Vec::<u8>::try_from(v).ok())
+                .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+                .unwrap_or_else(|| id.clone());
+            let security = if settings.contains_key("802-11-wireless-security") {
+                if settings.contains_key("802-1x") {
+                    SecurityType::Enterprise
+                } else {
+                    SecurityType::WPA
+                }
+            } else {
+                SecurityType::Open
+            };
+
+            wifi_connections.push(ConnectionInfo {
+                path: path.clone(),
+                id,
+                uuid: setting_str(connection, "uuid").unwrap_or_default(),
+                ssid,
+                // NetworkManager omits `autoconnect` when it is at its default of true.
+                autoconnect: setting_bool(connection, "autoconnect").unwrap_or(true),
+                timestamp: setting_u64(connection, "timestamp").unwrap_or(0),
+                hidden: wireless
+                    .and_then(|w| setting_bool(w, "hidden"))
+                    .unwrap_or(false),
+                security,
+            });
         }
 
         // Sort by timestamp (most recent first)
         wifi_connections.sort_by_key(|c| std::cmp::Reverse(c.timestamp));
 
-        if let Ok(mut guard) = self.wifi_conn_cache.lock() {
-            *guard = Some(WifiConnCache {
-                fingerprint,
-                connections: wifi_connections.clone(),
-            });
+        let connections: Arc<[ConnectionInfo]> = wifi_connections.into();
+        self.store_wifi_connections(versions, &connections);
+        Ok(connections)
+    }
+
+    /// The previously built profile list, when `versions` still describes it.
+    fn cached_wifi_connections(
+        &self,
+        versions: &[(String, Option<u64>)],
+    ) -> Option<Arc<[ConnectionInfo]>> {
+        let guard = self.lock_wifi_connection_cache();
+        let cache = guard.as_ref()?;
+        (cache.versions == versions).then(|| Arc::clone(&cache.connections))
+    }
+
+    /// Remembers `connections` against the versions they were built from.
+    ///
+    /// A list containing an unreadable version is not stored: it could not be
+    /// invalidated reliably, so serving it again later would be a guess.
+    fn store_wifi_connections(
+        &self,
+        versions: Vec<(String, Option<u64>)>,
+        connections: &Arc<[ConnectionInfo]>,
+    ) {
+        if versions.iter().any(|(_, version)| version.is_none()) {
+            return;
         }
 
-        Ok(wifi_connections)
+        *self.lock_wifi_connection_cache() = Some(WifiConnectionCache {
+            versions,
+            connections: Arc::clone(connections),
+        });
+    }
+
+    /// The cache holds plain data with no invariant a panic could leave broken,
+    /// so a poisoned lock is recovered rather than propagated. Abandoning the
+    /// cache would silently reinstate the per-profile read storm it prevents.
+    fn lock_wifi_connection_cache(&self) -> MutexGuard<'_, Option<WifiConnectionCache>> {
+        self.wifi_connection_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// List saved VPN / WireGuard connection profiles, sorted by name.
@@ -674,24 +584,17 @@ impl NMClient {
 
     /// Names of the VPN / WireGuard profiles that are currently activated.
     /// Drives the always-on VPN indicator without opening the modal.
-    pub async fn get_active_vpn_names(&self) -> Result<Vec<String>> {
-        let mut names = Vec::new();
-
-        for active_path in self.get_active_connections().await? {
-            let Ok(info) = self.get_active_connection_info(active_path.as_str()).await else {
-                continue;
-            };
-            if info.state != ActiveConnectionState::Activated {
-                continue;
-            }
-            let is_vpn = info.connection_type == "vpn" || info.connection_type == "wireguard";
-            if is_vpn {
-                names.push(info.id);
-            }
-        }
+    pub fn active_vpn_names(&self, snapshot: &NmSnapshot) -> Vec<String> {
+        let mut names: Vec<String> = snapshot
+            .active_connections()
+            .into_iter()
+            .filter(|info| info.state == ActiveConnectionState::Activated)
+            .filter(|info| info.connection_type == "vpn" || info.connection_type == "wireguard")
+            .map(|info| info.id)
+            .collect();
 
         names.sort_by_key(|n| n.to_lowercase());
-        Ok(names)
+        names
     }
 
     /// First IPv4 address (as `addr/prefix`) assigned to an active connection,
@@ -1100,8 +1003,8 @@ impl NMClient {
     }
 
     /// Check if there's an active Ethernet connection.
-    pub async fn has_active_ethernet_connection(&self) -> Result<bool> {
-        Ok(self.active_ethernet().await?.is_some())
+    pub async fn has_active_ethernet_connection(&self, snapshot: &NmSnapshot) -> Result<bool> {
+        Ok(self.active_ethernet(snapshot).await?.is_some())
     }
 
     /// Details of the first activated wired (`802-3-ethernet`) connection, if
@@ -1109,13 +1012,8 @@ impl NMClient {
     /// shown even while the WiFi radio is off. Includes the device interface
     /// and primary IPv4 address when they can be read; those are best-effort
     /// and left `None` rather than failing the whole lookup.
-    pub async fn active_ethernet(&self) -> Result<Option<EthernetInfo>> {
-        let active_connections = self.get_active_connections().await?;
-
-        for conn_path in active_connections {
-            let Ok(info) = self.get_active_connection_info(conn_path.as_str()).await else {
-                continue;
-            };
+    pub async fn active_ethernet(&self, snapshot: &NmSnapshot) -> Result<Option<EthernetInfo>> {
+        for info in snapshot.active_connections() {
             if info.state != ActiveConnectionState::Activated {
                 continue;
             }
@@ -1125,10 +1023,9 @@ impl NMClient {
             }
 
             let device_path = info.devices.first().cloned();
-            let interface = match &device_path {
-                Some(path) => self.get_device_interface(path).await.ok(),
-                None => None,
-            };
+            let interface = device_path
+                .as_deref()
+                .and_then(|path| snapshot.device_interface(path));
             let ipv4 = match &device_path {
                 Some(path) => self
                     .get_ip4_info(path)
@@ -1152,26 +1049,11 @@ impl NMClient {
     /// The connection NetworkManager is currently using as the default route —
     /// the link that actually carries internet traffic. `None` when NM reports
     /// no primary connection (e.g. nothing is online).
-    pub async fn primary_link(&self) -> Result<Option<PrimaryLink>> {
-        let proxy = Proxy::new(
-            &self.connection,
-            NM_BUS_NAME,
-            NM_PATH,
-            "org.freedesktop.NetworkManager",
-        )
-        .await?;
-
-        let path: OwnedObjectPath = proxy.get_property("PrimaryConnection").await?;
-        if path.as_str() == "/" {
-            return Ok(None);
-        }
-
-        let info = self.get_active_connection_info(path.as_str()).await?;
-
-        Ok(Some(PrimaryLink {
+    pub fn primary_link(&self, snapshot: &NmSnapshot) -> Option<PrimaryLink> {
+        snapshot.primary_connection().map(|info| PrimaryLink {
             id: info.id,
             kind: LinkKind::from_nm_type(&info.connection_type),
-        }))
+        })
     }
 
     /// Activated WiFi / Ethernet connections paired with their device, used to
@@ -1288,51 +1170,10 @@ impl NMClient {
         .await?;
 
         let props: HashMap<String, OwnedValue> = proxy
-            .call(
-                "GetAll",
-                &("org.freedesktop.NetworkManager.Connection.Active",),
-            )
+            .call("GetAll", &(snapshot::interface::CONNECTION_ACTIVE,))
             .await?;
-        let id: String = props
-            .get("Id")
-            .context("Active connection has no Id")?
-            .try_clone()?
-            .try_into()?;
-        let uuid: String = props
-            .get("Uuid")
-            .context("Active connection has no Uuid")?
-            .try_clone()?
-            .try_into()?;
-        let connection_type: String = props
-            .get("Type")
-            .context("Active connection has no Type")?
-            .try_clone()?
-            .try_into()?;
-        let state: u32 = props
-            .get("State")
-            .context("Active connection has no State")?
-            .try_clone()?
-            .try_into()?;
-        let connection_path: OwnedObjectPath = props
-            .get("Connection")
-            .context("Active connection has no Connection")?
-            .try_clone()?
-            .try_into()?;
-        let devices: Vec<OwnedObjectPath> = props
-            .get("Devices")
-            .context("Active connection has no Devices")?
-            .try_clone()?
-            .try_into()?;
 
-        Ok(ActiveConnectionInfo {
-            path: active_conn_path.to_string(),
-            id,
-            uuid,
-            connection_type,
-            state: ActiveConnectionState::from(state),
-            connection_path: connection_path.to_string(),
-            devices: devices.iter().map(|p| p.to_string()).collect(),
-        })
+        Ok(snapshot::active_connection_info(active_conn_path, &props))
     }
 
     /// Wait for an activation attempt to reach a terminal state.

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -1002,11 +1002,6 @@ impl NMClient {
         Ok(proxy.get_property("ActiveConnections").await?)
     }
 
-    /// Check if there's an active Ethernet connection.
-    pub async fn has_active_ethernet_connection(&self, snapshot: &NmSnapshot) -> Result<bool> {
-        Ok(self.active_ethernet(snapshot).await?.is_some())
-    }
-
     /// Details of the first activated wired (`802-3-ethernet`) connection, if
     /// any. Resolved independently of the WiFi device so link status can be
     /// shown even while the WiFi radio is off. Includes the device interface

--- a/src/nm/mod.rs
+++ b/src/nm/mod.rs
@@ -684,13 +684,7 @@ impl NMClient {
             if info.state != ActiveConnectionState::Activated {
                 continue;
             }
-            let Ok(settings) = self.get_connection_settings(&info.connection_path).await else {
-                continue;
-            };
-            let is_vpn = settings
-                .get("connection")
-                .and_then(|c| setting_str(c, "type"))
-                .is_some_and(|t| t == "vpn" || t == "wireguard");
+            let is_vpn = info.connection_type == "vpn" || info.connection_type == "wireguard";
             if is_vpn {
                 names.push(info.id);
             }
@@ -1126,17 +1120,7 @@ impl NMClient {
                 continue;
             }
 
-            // 802-3-ethernet is the NetworkManager type for wired connections.
-            let Ok(settings) = self.get_connection_settings(&info.connection_path).await else {
-                continue;
-            };
-            let is_ethernet = settings
-                .get("connection")
-                .and_then(|c| c.get("type"))
-                .and_then(|t| t.try_clone().ok())
-                .and_then(|t| String::try_from(t).ok())
-                .is_some_and(|t| t == "802-3-ethernet");
-            if !is_ethernet {
+            if info.connection_type != "802-3-ethernet" {
                 continue;
             }
 
@@ -1183,14 +1167,10 @@ impl NMClient {
         }
 
         let info = self.get_active_connection_info(path.as_str()).await?;
-        let nm_type: String = proxy
-            .get_property("PrimaryConnectionType")
-            .await
-            .unwrap_or_default();
 
         Ok(Some(PrimaryLink {
             id: info.id,
-            kind: LinkKind::from_nm_type(&nm_type),
+            kind: LinkKind::from_nm_type(&info.connection_type),
         }))
     }
 
@@ -1208,16 +1188,7 @@ impl NMClient {
                 continue;
             }
 
-            let Ok(settings) = self.get_connection_settings(&info.connection_path).await else {
-                continue;
-            };
-            let nm_type = settings
-                .get("connection")
-                .and_then(|c| c.get("type"))
-                .and_then(|t| t.try_clone().ok())
-                .and_then(|t| String::try_from(t).ok())
-                .unwrap_or_default();
-            let kind = LinkKind::from_nm_type(&nm_type);
+            let kind = LinkKind::from_nm_type(&info.connection_type);
             if kind == LinkKind::Other {
                 continue;
             }
@@ -1312,20 +1283,52 @@ impl NMClient {
             &self.connection,
             NM_BUS_NAME,
             active_conn_path,
-            "org.freedesktop.NetworkManager.Connection.Active",
+            "org.freedesktop.DBus.Properties",
         )
         .await?;
 
-        let id: String = proxy.get_property("Id").await?;
-        let uuid: String = proxy.get_property("Uuid").await?;
-        let state: u32 = proxy.get_property("State").await?;
-        let connection_path: OwnedObjectPath = proxy.get_property("Connection").await?;
-        let devices: Vec<OwnedObjectPath> = proxy.get_property("Devices").await?;
+        let props: HashMap<String, OwnedValue> = proxy
+            .call(
+                "GetAll",
+                &("org.freedesktop.NetworkManager.Connection.Active",),
+            )
+            .await?;
+        let id: String = props
+            .get("Id")
+            .context("Active connection has no Id")?
+            .try_clone()?
+            .try_into()?;
+        let uuid: String = props
+            .get("Uuid")
+            .context("Active connection has no Uuid")?
+            .try_clone()?
+            .try_into()?;
+        let connection_type: String = props
+            .get("Type")
+            .context("Active connection has no Type")?
+            .try_clone()?
+            .try_into()?;
+        let state: u32 = props
+            .get("State")
+            .context("Active connection has no State")?
+            .try_clone()?
+            .try_into()?;
+        let connection_path: OwnedObjectPath = props
+            .get("Connection")
+            .context("Active connection has no Connection")?
+            .try_clone()?
+            .try_into()?;
+        let devices: Vec<OwnedObjectPath> = props
+            .get("Devices")
+            .context("Active connection has no Devices")?
+            .try_clone()?
+            .try_into()?;
 
         Ok(ActiveConnectionInfo {
             path: active_conn_path.to_string(),
             id,
             uuid,
+            connection_type,
             state: ActiveConnectionState::from(state),
             connection_path: connection_path.to_string(),
             devices: devices.iter().map(|p| p.to_string()).collect(),

--- a/src/nm/snapshot.rs
+++ b/src/nm/snapshot.rs
@@ -265,3 +265,298 @@ impl NmSnapshot {
         self.objects.get(&object_path)?.get(interface)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zbus::zvariant::Value;
+
+    fn value<'a>(v: impl Into<Value<'a>>) -> OwnedValue {
+        OwnedValue::try_from(v.into()).expect("value is convertible")
+    }
+
+    fn object_path(path: &str) -> OwnedObjectPath {
+        OwnedObjectPath::try_from(path.to_string()).expect("valid object path")
+    }
+
+    fn access_point_props(ssid: &str, strength: u8) -> HashMap<String, OwnedValue> {
+        HashMap::from([
+            ("Ssid".to_string(), value(ssid.as_bytes().to_vec())),
+            ("Strength".to_string(), value(strength)),
+            ("Frequency".to_string(), value(2437u32)),
+            ("HwAddress".to_string(), value("00:11:22:33:44:55")),
+            ("Flags".to_string(), value(0u32)),
+            ("WpaFlags".to_string(), value(0u32)),
+            ("RsnFlags".to_string(), value(0u32)),
+            ("Mode".to_string(), value(2u32)),
+        ])
+    }
+
+    fn snapshot_of(objects: Vec<(&str, &str, HashMap<String, OwnedValue>)>) -> NmSnapshot {
+        let mut map: ManagedObjects = HashMap::new();
+        for (path, interface, props) in objects {
+            map.entry(object_path(path))
+                .or_default()
+                .insert(interface.to_string(), props);
+        }
+        NmSnapshot { objects: map }
+    }
+
+    #[test]
+    fn access_point_info_reads_properties() {
+        let info = access_point_info("/ap/1", &access_point_props("home", 71));
+
+        assert_eq!(info.path, "/ap/1");
+        assert_eq!(info.ssid, "home");
+        assert_eq!(info.strength, 71);
+        assert_eq!(info.frequency, 2437);
+        assert_eq!(info.hw_address, "00:11:22:33:44:55");
+    }
+
+    /// A snapshot can race an access point out of existence, so a partial
+    /// property map must degrade rather than panic or fail the refresh.
+    #[test]
+    fn access_point_info_defaults_absent_properties() {
+        let info = access_point_info("/ap/1", &HashMap::new());
+
+        assert_eq!(info.ssid, "");
+        assert_eq!(info.strength, 0);
+        assert_eq!(info.frequency, 0);
+        assert_eq!(info.hw_address, "");
+    }
+
+    #[test]
+    fn visible_networks_keeps_strongest_of_duplicate_ssids() {
+        let snapshot = snapshot_of(vec![
+            (
+                "/dev/1",
+                interface::DEVICE_WIRELESS,
+                HashMap::from([(
+                    "AccessPoints".to_string(),
+                    value(vec![object_path("/ap/1"), object_path("/ap/2")]),
+                )]),
+            ),
+            (
+                "/ap/1",
+                interface::ACCESS_POINT,
+                access_point_props("home", 40),
+            ),
+            (
+                "/ap/2",
+                interface::ACCESS_POINT,
+                access_point_props("home", 90),
+            ),
+        ]);
+
+        let networks = snapshot.visible_networks("/dev/1");
+
+        assert_eq!(networks.len(), 1);
+        assert_eq!(networks[0].strength, 90);
+    }
+
+    #[test]
+    fn visible_networks_skips_empty_ssids_and_sorts_by_strength() {
+        let snapshot = snapshot_of(vec![
+            (
+                "/dev/1",
+                interface::DEVICE_WIRELESS,
+                HashMap::from([(
+                    "AccessPoints".to_string(),
+                    value(vec![
+                        object_path("/ap/1"),
+                        object_path("/ap/2"),
+                        object_path("/ap/3"),
+                    ]),
+                )]),
+            ),
+            (
+                "/ap/1",
+                interface::ACCESS_POINT,
+                access_point_props("weak", 20),
+            ),
+            ("/ap/2", interface::ACCESS_POINT, access_point_props("", 99)),
+            (
+                "/ap/3",
+                interface::ACCESS_POINT,
+                access_point_props("strong", 80),
+            ),
+        ]);
+
+        let ssids: Vec<String> = snapshot
+            .visible_networks("/dev/1")
+            .into_iter()
+            .map(|n| n.ssid)
+            .collect();
+
+        assert_eq!(ssids, vec!["strong", "weak"]);
+    }
+
+    #[test]
+    fn visible_networks_is_empty_for_unknown_device() {
+        let snapshot = snapshot_of(vec![]);
+        assert!(snapshot.visible_networks("/dev/missing").is_empty());
+    }
+
+    #[test]
+    fn active_access_point_is_none_when_unassociated() {
+        let snapshot = snapshot_of(vec![(
+            "/dev/1",
+            interface::DEVICE_WIRELESS,
+            HashMap::from([("ActiveAccessPoint".to_string(), value(object_path("/")))]),
+        )]);
+
+        assert!(snapshot.active_access_point("/dev/1").is_none());
+    }
+
+    #[test]
+    fn active_access_point_resolves_through_the_snapshot() {
+        let snapshot = snapshot_of(vec![
+            (
+                "/dev/1",
+                interface::DEVICE_WIRELESS,
+                HashMap::from([("ActiveAccessPoint".to_string(), value(object_path("/ap/7")))]),
+            ),
+            (
+                "/ap/7",
+                interface::ACCESS_POINT,
+                access_point_props("home", 55),
+            ),
+        ]);
+
+        let active = snapshot.active_access_point("/dev/1").expect("resolves");
+        assert_eq!(active.ssid, "home");
+        assert_eq!(active.strength, 55);
+    }
+
+    /// The list is compared as a whole to decide whether saved profiles changed,
+    /// so it has to be ordered independently of the map's iteration order.
+    #[test]
+    fn connection_versions_are_sorted() {
+        let snapshot = snapshot_of(vec![
+            (
+                "/settings/2",
+                interface::SETTINGS_CONNECTION,
+                HashMap::from([("VersionId".to_string(), value(9u64))]),
+            ),
+            (
+                "/settings/1",
+                interface::SETTINGS_CONNECTION,
+                HashMap::from([("VersionId".to_string(), value(3u64))]),
+            ),
+        ]);
+
+        assert_eq!(
+            snapshot.connection_versions(),
+            vec![
+                ("/settings/1".to_string(), Some(3)),
+                ("/settings/2".to_string(), Some(9)),
+            ]
+        );
+    }
+
+    /// An unreadable version must stay distinguishable from a real one, since
+    /// it is the key that decides whether cached profiles are still valid.
+    #[test]
+    fn connection_versions_keep_unreadable_versions_unknown() {
+        let snapshot = snapshot_of(vec![(
+            "/settings/1",
+            interface::SETTINGS_CONNECTION,
+            HashMap::new(),
+        )]);
+
+        assert_eq!(
+            snapshot.connection_versions(),
+            vec![("/settings/1".to_string(), None)]
+        );
+    }
+
+    #[test]
+    fn connection_versions_ignore_non_profile_objects() {
+        let snapshot = snapshot_of(vec![(
+            "/ap/1",
+            interface::ACCESS_POINT,
+            access_point_props("home", 50),
+        )]);
+
+        assert!(snapshot.connection_versions().is_empty());
+    }
+
+    /// Adapter rows are diffed positionally each refresh, so this must follow
+    /// NetworkManager's own ordering rather than map iteration order.
+    #[test]
+    fn wifi_devices_keep_manager_order_and_skip_other_types() {
+        let device = |kind: u32| HashMap::from([("DeviceType".to_string(), value(kind))]);
+        let snapshot = snapshot_of(vec![
+            (
+                "/org/freedesktop/NetworkManager",
+                interface::NETWORK_MANAGER,
+                HashMap::from([(
+                    "Devices".to_string(),
+                    value(vec![
+                        object_path("/dev/3"),
+                        object_path("/dev/1"),
+                        object_path("/dev/2"),
+                    ]),
+                )]),
+            ),
+            ("/dev/1", interface::DEVICE, device(WIFI_DEVICE_TYPE)),
+            ("/dev/2", interface::DEVICE, device(1)),
+            ("/dev/3", interface::DEVICE, device(WIFI_DEVICE_TYPE)),
+        ]);
+
+        let paths: Vec<String> = snapshot
+            .wifi_devices()
+            .iter()
+            .map(|p| p.as_str().to_string())
+            .collect();
+
+        assert_eq!(paths, vec!["/dev/3", "/dev/1"]);
+    }
+
+    #[test]
+    fn device_state_and_interface_read_from_the_device_interface() {
+        let snapshot = snapshot_of(vec![(
+            "/dev/1",
+            interface::DEVICE,
+            HashMap::from([
+                ("Interface".to_string(), value("wlan0")),
+                ("State".to_string(), value(100u32)),
+            ]),
+        )]);
+
+        assert_eq!(
+            snapshot.device_interface("/dev/1").as_deref(),
+            Some("wlan0")
+        );
+        assert_eq!(
+            snapshot.device_state("/dev/1"),
+            Some(DeviceState::Activated)
+        );
+        assert!(snapshot.device_state("/dev/missing").is_none());
+    }
+
+    #[test]
+    fn active_connection_info_defaults_absent_properties() {
+        let info = active_connection_info("/active/1", &HashMap::new());
+
+        assert_eq!(info.path, "/active/1");
+        assert_eq!(info.id, "");
+        assert_eq!(info.connection_type, "");
+        assert!(info.devices.is_empty());
+    }
+
+    #[test]
+    fn active_connection_info_reads_devices() {
+        let props = HashMap::from([
+            ("Id".to_string(), value("wired")),
+            ("Type".to_string(), value("802-3-ethernet")),
+            ("Devices".to_string(), value(vec![object_path("/dev/2")])),
+        ]);
+
+        let info = active_connection_info("/active/1", &props);
+
+        assert_eq!(info.id, "wired");
+        assert_eq!(info.connection_type, "802-3-ethernet");
+        assert_eq!(info.devices, vec!["/dev/2".to_string()]);
+    }
+}

--- a/src/nm/snapshot.rs
+++ b/src/nm/snapshot.rs
@@ -1,0 +1,267 @@
+// Single-read view of NetworkManager's exported object graph.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use zbus::Proxy;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue};
+
+use super::{
+    AccessPointInfo, ActiveConnectionInfo, ActiveConnectionState, DeviceState, NM_BUS_NAME,
+    NMClient, SecurityType, WifiMode,
+};
+
+/// NetworkManager exports its ObjectManager under the shared `/org/freedesktop`
+/// path rather than beneath its own `/org/freedesktop/NetworkManager` tree.
+const OBJECT_MANAGER_PATH: &str = "/org/freedesktop";
+
+/// D-Bus interface names read out of a snapshot.
+pub(crate) mod interface {
+    pub const ACCESS_POINT: &str = "org.freedesktop.NetworkManager.AccessPoint";
+    pub const CONNECTION_ACTIVE: &str = "org.freedesktop.NetworkManager.Connection.Active";
+    pub const DEVICE: &str = "org.freedesktop.NetworkManager.Device";
+    pub const DEVICE_WIRELESS: &str = "org.freedesktop.NetworkManager.Device.Wireless";
+    pub const NETWORK_MANAGER: &str = "org.freedesktop.NetworkManager";
+    pub const SETTINGS_CONNECTION: &str = "org.freedesktop.NetworkManager.Settings.Connection";
+}
+
+/// `NM_DEVICE_TYPE_WIFI`.
+const WIFI_DEVICE_TYPE: u32 = 2;
+
+/// Object path -> interface name -> property name -> value, as returned by a
+/// single `GetManagedObjects` call.
+type ManagedObjects = HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>>;
+
+/// Reads one property out of a D-Bus property map, yielding `None` when it is
+/// absent or not convertible to `T`.
+fn prop<T>(props: &HashMap<String, OwnedValue>, key: &str) -> Option<T>
+where
+    T: TryFrom<OwnedValue>,
+{
+    props.get(key)?.try_clone().ok()?.try_into().ok()
+}
+
+/// Builds an `AccessPointInfo` from an `AccessPoint` interface's properties,
+/// whichever way they were fetched.
+///
+/// Missing properties fall back to zero rather than failing: a snapshot can
+/// legitimately race an access point out of existence, and a momentarily
+/// under-described network reads better than a refresh that aborts.
+pub(crate) fn access_point_info(
+    ap_path: &str,
+    props: &HashMap<String, OwnedValue>,
+) -> AccessPointInfo {
+    let ssid_bytes: Vec<u8> = prop(props, "Ssid").unwrap_or_default();
+
+    AccessPointInfo {
+        path: ap_path.to_string(),
+        ssid: String::from_utf8_lossy(&ssid_bytes).to_string(),
+        strength: prop(props, "Strength").unwrap_or(0),
+        frequency: prop(props, "Frequency").unwrap_or(0),
+        hw_address: prop(props, "HwAddress").unwrap_or_default(),
+        security: SecurityType::from_flags(
+            prop(props, "Flags").unwrap_or(0),
+            prop(props, "WpaFlags").unwrap_or(0),
+            prop(props, "RsnFlags").unwrap_or(0),
+        ),
+        mode: WifiMode::from(prop::<u32>(props, "Mode").unwrap_or(0)),
+    }
+}
+
+/// Builds an `ActiveConnectionInfo` from a `Connection.Active` interface's
+/// properties, whichever way they were fetched.
+///
+/// A connection can deactivate while it is being read, so absent properties
+/// fall back to empty rather than failing and taking a whole refresh with them.
+pub(crate) fn active_connection_info(
+    path: &str,
+    props: &HashMap<String, OwnedValue>,
+) -> ActiveConnectionInfo {
+    let devices: Vec<OwnedObjectPath> = prop(props, "Devices").unwrap_or_default();
+
+    ActiveConnectionInfo {
+        path: path.to_string(),
+        id: prop(props, "Id").unwrap_or_default(),
+        uuid: prop(props, "Uuid").unwrap_or_default(),
+        connection_type: prop(props, "Type").unwrap_or_default(),
+        state: ActiveConnectionState::from(prop::<u32>(props, "State").unwrap_or(0)),
+        connection_path: prop::<OwnedObjectPath>(props, "Connection")
+            .map(|path| path.as_str().to_string())
+            .unwrap_or_default(),
+        devices: devices
+            .iter()
+            .map(|path| path.as_str().to_string())
+            .collect(),
+    }
+}
+
+/// A point-in-time view of every object NetworkManager exports.
+///
+/// The UI re-reads every access point and saved profile on a timer, and reading
+/// them one object at a time costs a D-Bus round trip each — and a zbus proxy
+/// property read costs more than that, since it also registers a match rule and
+/// spawns a cache task it immediately drops. One `GetManagedObjects` replaces
+/// all of them, so a single snapshot can serve an entire refresh, and every
+/// value read from it is consistent with every other.
+///
+/// Deliberately neither `Clone` nor `Debug`: copying the object graph is the
+/// cost this type exists to avoid, and printing it would dump the whole bus.
+pub struct NmSnapshot {
+    objects: ManagedObjects,
+}
+
+impl NmSnapshot {
+    pub async fn fetch(client: &NMClient) -> Result<Self> {
+        let proxy = Proxy::new(
+            client.connection(),
+            NM_BUS_NAME,
+            OBJECT_MANAGER_PATH,
+            "org.freedesktop.DBus.ObjectManager",
+        )
+        .await?;
+
+        Ok(Self {
+            objects: proxy.call("GetManagedObjects", &()).await?,
+        })
+    }
+
+    /// Whether the WiFi radio is enabled.
+    pub fn wireless_enabled(&self) -> Option<bool> {
+        let manager = self.interface_props(super::NM_PATH, interface::NETWORK_MANAGER)?;
+        prop(manager, "WirelessEnabled")
+    }
+
+    /// WiFi devices, in the order NetworkManager lists them so the adapter
+    /// table keeps a stable row order between refreshes.
+    pub fn wifi_devices(&self) -> Vec<OwnedObjectPath> {
+        let Some(manager) = self.interface_props(super::NM_PATH, interface::NETWORK_MANAGER) else {
+            return Vec::new();
+        };
+        let devices: Vec<OwnedObjectPath> = prop(manager, "Devices").unwrap_or_default();
+
+        devices
+            .into_iter()
+            .filter(|path| {
+                self.device_props(path)
+                    .and_then(|props| prop::<u32>(props, "DeviceType"))
+                    == Some(WIFI_DEVICE_TYPE)
+            })
+            .collect()
+    }
+
+    /// A device's kernel interface name, e.g. `wlan0`.
+    pub fn device_interface(&self, device_path: &str) -> Option<String> {
+        prop(
+            self.interface_props(device_path, interface::DEVICE)?,
+            "Interface",
+        )
+    }
+
+    /// A device's current NetworkManager state.
+    pub fn device_state(&self, device_path: &str) -> Option<DeviceState> {
+        let props = self.interface_props(device_path, interface::DEVICE)?;
+        prop::<u32>(props, "State").map(DeviceState::from)
+    }
+
+    fn device_props(&self, path: &OwnedObjectPath) -> Option<&HashMap<String, OwnedValue>> {
+        self.objects.get(path)?.get(interface::DEVICE)
+    }
+
+    /// Access points the device can currently see: deduplicated by SSID keeping
+    /// the strongest signal, then sorted strongest first.
+    pub fn visible_networks(&self, device_path: &str) -> Vec<AccessPointInfo> {
+        let Some(device) = self.interface_props(device_path, interface::DEVICE_WIRELESS) else {
+            return Vec::new();
+        };
+        let ap_paths: Vec<OwnedObjectPath> = prop(device, "AccessPoints").unwrap_or_default();
+
+        let mut networks: Vec<AccessPointInfo> = Vec::new();
+        for ap_path in ap_paths {
+            let Some(ap) = self.access_point(&ap_path) else {
+                continue;
+            };
+            // A hidden network is exported with an empty SSID until one is
+            // observed, and has nothing to show in a network list.
+            if ap.ssid.is_empty() {
+                continue;
+            }
+
+            match networks.iter_mut().find(|known| known.ssid == ap.ssid) {
+                Some(weaker) if ap.strength > weaker.strength => *weaker = ap,
+                Some(_) => {}
+                None => networks.push(ap),
+            }
+        }
+
+        networks.sort_by_key(|n| std::cmp::Reverse(n.strength));
+        networks
+    }
+
+    /// The access point the device is currently associated with.
+    pub fn active_access_point(&self, device_path: &str) -> Option<AccessPointInfo> {
+        let device = self.interface_props(device_path, interface::DEVICE_WIRELESS)?;
+        let ap_path: OwnedObjectPath = prop(device, "ActiveAccessPoint")?;
+
+        // NetworkManager reports "no active access point" as the root path.
+        if ap_path.as_str() == "/" {
+            return None;
+        }
+        self.access_point(&ap_path)
+    }
+
+    /// Every connection NetworkManager currently reports as active, in no
+    /// particular order.
+    pub fn active_connections(&self) -> Vec<ActiveConnectionInfo> {
+        self.objects
+            .iter()
+            .filter_map(|(path, interfaces)| {
+                let props = interfaces.get(interface::CONNECTION_ACTIVE)?;
+                Some(active_connection_info(path.as_str(), props))
+            })
+            .collect()
+    }
+
+    /// The connection carrying the default route — the link actually reaching
+    /// the internet — when NetworkManager reports one.
+    pub fn primary_connection(&self) -> Option<ActiveConnectionInfo> {
+        let manager = self.interface_props(super::NM_PATH, interface::NETWORK_MANAGER)?;
+        let path: OwnedObjectPath = prop(manager, "PrimaryConnection")?;
+        if path.as_str() == "/" {
+            return None;
+        }
+
+        let props = self.objects.get(&path)?.get(interface::CONNECTION_ACTIVE)?;
+        Some(active_connection_info(path.as_str(), props))
+    }
+
+    /// `(path, VersionId)` for every saved profile, sorted so it can be compared
+    /// as a whole. NetworkManager bumps `VersionId` on every edit, so an equal
+    /// pair of these means no profile was added, removed, or changed.
+    ///
+    /// An unreadable version stays `None` rather than defaulting: this is a
+    /// cache key, and a version that silently reads as a real one would pin the
+    /// profile to a stale entry for the rest of the process.
+    pub(crate) fn connection_versions(&self) -> Vec<(String, Option<u64>)> {
+        let mut versions: Vec<(String, Option<u64>)> = self
+            .objects
+            .iter()
+            .filter_map(|(path, interfaces)| {
+                let props = interfaces.get(interface::SETTINGS_CONNECTION)?;
+                Some((path.as_str().to_string(), prop(props, "VersionId")))
+            })
+            .collect();
+
+        versions.sort();
+        versions
+    }
+
+    fn access_point(&self, ap_path: &OwnedObjectPath) -> Option<AccessPointInfo> {
+        let props = self.objects.get(ap_path)?.get(interface::ACCESS_POINT)?;
+        Some(access_point_info(ap_path.as_str(), props))
+    }
+
+    fn interface_props(&self, path: &str, interface: &str) -> Option<&HashMap<String, OwnedValue>> {
+        let object_path = OwnedObjectPath::try_from(path.to_string()).ok()?;
+        self.objects.get(&object_path)?.get(interface)
+    }
+}

--- a/src/nm/types.rs
+++ b/src/nm/types.rs
@@ -505,6 +505,7 @@ pub struct ActiveConnectionInfo {
     pub path: String,
     pub id: String,
     pub uuid: String,
+    pub connection_type: String,
     pub state: ActiveConnectionState,
     pub connection_path: String,
     pub devices: Vec<String>,

--- a/src/nm/wifi.rs
+++ b/src/nm/wifi.rs
@@ -1,93 +1,30 @@
 // WiFi-specific helpers for NetworkManager
 
-use super::{AccessPointInfo, ManagedObjects, NMClient};
+use super::{AccessPointInfo, NMClient, NmSnapshot};
 use anyhow::Result;
-use zbus::zvariant::OwnedObjectPath;
 
 impl NMClient {
-    /// Get all visible networks, deduplicated by SSID
+    /// Get all visible networks, deduplicated by SSID.
+    ///
+    /// Prefer [`NmSnapshot::visible_networks`] when the caller already holds a
+    /// snapshot; this reads a fresh one.
     pub async fn get_visible_networks(&self, device_path: &str) -> Result<Vec<AccessPointInfo>> {
-        let managed = self.get_managed_objects().await?;
-        self.get_visible_networks_from_managed(device_path, &managed)
-            .await
-    }
-
-    /// Get all visible networks using an existing ObjectManager snapshot.
-    pub async fn get_visible_networks_from_managed(
-        &self,
-        device_path: &str,
-        managed: &ManagedObjects,
-    ) -> Result<Vec<AccessPointInfo>> {
-        const AP_IFACE: &str = "org.freedesktop.NetworkManager.AccessPoint";
-        let aps = self.get_access_points(device_path).await?;
-        let mut networks: Vec<AccessPointInfo> = Vec::new();
-
-        for ap_path in aps {
-            let Some(props) = managed
-                .get(&ap_path)
-                .and_then(|ifaces| ifaces.get(AP_IFACE))
-            else {
-                continue;
-            };
-            let ap_info = NMClient::access_point_info_from_props(ap_path.as_str(), props);
-
-            // Skip empty SSIDs (hidden networks show up with empty SSID)
-            if ap_info.ssid.is_empty() {
-                continue;
-            }
-
-            // Deduplicate by SSID, keeping the one with strongest signal
-            if let Some(existing) = networks.iter_mut().find(|n| n.ssid == ap_info.ssid) {
-                if ap_info.strength > existing.strength {
-                    *existing = ap_info;
-                }
-            } else {
-                networks.push(ap_info);
-            }
-        }
-
-        // Sort by signal strength (strongest first)
-        networks.sort_by_key(|n| std::cmp::Reverse(n.strength));
-
-        Ok(networks)
-    }
-
-    /// Read one access point from an existing ObjectManager snapshot.
-    pub fn get_access_point_info_from_managed(
-        &self,
-        ap_path: &OwnedObjectPath,
-        managed: &ManagedObjects,
-    ) -> Option<AccessPointInfo> {
-        const AP_IFACE: &str = "org.freedesktop.NetworkManager.AccessPoint";
-        let props = managed.get(ap_path)?.get(AP_IFACE)?;
-        Some(NMClient::access_point_info_from_props(
-            ap_path.as_str(),
-            props,
-        ))
+        let snapshot = NmSnapshot::fetch(self).await?;
+        Ok(snapshot.visible_networks(device_path))
     }
 
     /// Find a saved connection for an SSID
     pub async fn find_connection_for_ssid(&self, ssid: &str) -> Result<Option<String>> {
         let connections = self.get_wifi_connections().await?;
         Ok(connections
-            .into_iter()
+            .iter()
             .find(|c| c.ssid == ssid)
-            .map(|c| c.path))
+            .map(|c| c.path.clone()))
     }
 
     /// Check if currently connected to any network
     pub async fn is_connected(&self, device_path: &str) -> Result<bool> {
         let state = self.get_device_state(device_path).await?;
         Ok(state == super::DeviceState::Activated)
-    }
-
-    /// Get the currently connected network name
-    pub async fn get_connected_ssid(&self, device_path: &str) -> Result<Option<String>> {
-        if let Some(ap_path) = self.get_active_access_point(device_path).await? {
-            let ap_info = self.get_access_point_info(ap_path.as_str()).await?;
-            Ok(Some(ap_info.ssid))
-        } else {
-            Ok(None)
-        }
     }
 }

--- a/src/nm/wifi.rs
+++ b/src/nm/wifi.rs
@@ -1,29 +1,48 @@
 // WiFi-specific helpers for NetworkManager
 
-use super::{AccessPointInfo, NMClient};
+use super::{AccessPointInfo, ManagedObjects, NMClient};
 use anyhow::Result;
+use zbus::zvariant::OwnedObjectPath;
 
 impl NMClient {
     /// Get all visible networks, deduplicated by SSID
     pub async fn get_visible_networks(&self, device_path: &str) -> Result<Vec<AccessPointInfo>> {
+        let managed = self.get_managed_objects().await?;
+        self.get_visible_networks_from_managed(device_path, &managed)
+            .await
+    }
+
+    /// Get all visible networks using an existing ObjectManager snapshot.
+    pub async fn get_visible_networks_from_managed(
+        &self,
+        device_path: &str,
+        managed: &ManagedObjects,
+    ) -> Result<Vec<AccessPointInfo>> {
+        const AP_IFACE: &str = "org.freedesktop.NetworkManager.AccessPoint";
         let aps = self.get_access_points(device_path).await?;
         let mut networks: Vec<AccessPointInfo> = Vec::new();
 
         for ap_path in aps {
-            if let Ok(ap_info) = self.get_access_point_info(ap_path.as_str()).await {
-                // Skip empty SSIDs (hidden networks show up with empty SSID)
-                if ap_info.ssid.is_empty() {
-                    continue;
-                }
+            let Some(props) = managed
+                .get(&ap_path)
+                .and_then(|ifaces| ifaces.get(AP_IFACE))
+            else {
+                continue;
+            };
+            let ap_info = NMClient::access_point_info_from_props(ap_path.as_str(), props);
 
-                // Deduplicate by SSID, keeping the one with strongest signal
-                if let Some(existing) = networks.iter_mut().find(|n| n.ssid == ap_info.ssid) {
-                    if ap_info.strength > existing.strength {
-                        *existing = ap_info;
-                    }
-                } else {
-                    networks.push(ap_info);
+            // Skip empty SSIDs (hidden networks show up with empty SSID)
+            if ap_info.ssid.is_empty() {
+                continue;
+            }
+
+            // Deduplicate by SSID, keeping the one with strongest signal
+            if let Some(existing) = networks.iter_mut().find(|n| n.ssid == ap_info.ssid) {
+                if ap_info.strength > existing.strength {
+                    *existing = ap_info;
                 }
+            } else {
+                networks.push(ap_info);
             }
         }
 
@@ -31,6 +50,20 @@ impl NMClient {
         networks.sort_by_key(|n| std::cmp::Reverse(n.strength));
 
         Ok(networks)
+    }
+
+    /// Read one access point from an existing ObjectManager snapshot.
+    pub fn get_access_point_info_from_managed(
+        &self,
+        ap_path: &OwnedObjectPath,
+        managed: &ManagedObjects,
+    ) -> Option<AccessPointInfo> {
+        const AP_IFACE: &str = "org.freedesktop.NetworkManager.AccessPoint";
+        let props = managed.get(ap_path)?.get(AP_IFACE)?;
+        Some(NMClient::access_point_info_from_props(
+            ap_path.as_str(),
+            props,
+        ))
     }
 
     /// Find a saved connection for an SSID

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use anyhow::Result;
 use ratatui::{
     Frame,
@@ -10,11 +12,16 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::event::Event;
 
+/// How long a notification stays on screen.
+const VISIBLE_FOR: Duration = Duration::from_secs(3);
+
 #[derive(Debug, Clone)]
 pub struct Notification {
     pub message: String,
     pub level: NotificationLevel,
-    pub ttl: u16,
+    /// Deadline rather than a countdown, so how long a notification is shown
+    /// does not depend on how often the UI happens to refresh.
+    expires_at: Instant,
 }
 
 #[derive(Debug, Clone)]
@@ -25,6 +32,11 @@ pub enum NotificationLevel {
 }
 
 impl Notification {
+    /// Whether this notification has outlived its display time.
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+
     pub fn render(&self, index: usize, frame: &mut Frame) {
         let (color, title) = match self.level {
             NotificationLevel::Info => (Color::Green, "Info"),
@@ -70,7 +82,7 @@ impl Notification {
         let notif = Notification {
             message,
             level,
-            ttl: 3,
+            expires_at: Instant::now() + VISIBLE_FOR,
         };
 
         sender.send(Event::Notification(notif))?;
@@ -103,4 +115,25 @@ pub fn notification_rect(offset: u16, height: u16, width: u16, r: Rect) -> Rect 
             .as_ref(),
         )
         .split(popup_layout[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn notification(expires_at: Instant) -> Notification {
+        Notification {
+            message: String::new(),
+            level: NotificationLevel::Info,
+            expires_at,
+        }
+    }
+
+    /// Expiry is a deadline, not a tick count, so the refresh interval cannot
+    /// stretch or shorten how long a notification is shown.
+    #[test]
+    fn expiry_depends_on_elapsed_time_only() {
+        assert!(!notification(Instant::now() + VISIBLE_FOR).is_expired());
+        assert!(notification(Instant::now()).is_expired());
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,6 +41,7 @@ impl<B: Backend> Tui<B> {
     }
 
     pub fn draw(&mut self, app: &mut App) -> Result<()> {
+        app.prune_expired_notifications();
         self.terminal.draw(|frame| ui::render(app, frame))?;
         Ok(())
     }


### PR DESCRIPTION
wlctl used a lot of CPU even when I was not doing anything. On my laptop it used about 11% CPU when idle. That felt like way too much for a little wifi app.

Every second, wlctl asks NetworkManager for lots of tiny things, one at a time. It asks about every wifi network it can see. It also asks about every wifi network I ever saved. I have almost 400 saved networks, so that is a huge pile of questions every single second.

I made it ask in a smarter way:

- It now asks for things in big groups instead of one at a time.
- It remembers the list of saved networks and only reads them again when they really change.
- When it looks at the network you are connected to, it reuses info it already grabbed instead of asking again.
- It checks a little less often (every 3 seconds instead of every 1 second). This should probably be a config or CLI value.

Now it uses about 0.2% when idles.


One small note: I could not test the ethernet part with a real wired cable plugged in, so that one path is not tested on hardware. It uses the same code as the wifi and VPN parts though, and those I did test.

If this PR is too big I can split it into a few smaller ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster, more consistent network status refreshes with reduced redundant background work.
  * Improved responsiveness during longer network operations.

* **Bug Fixes**
  * Improved accuracy of Wi‑Fi, Ethernet, VPN, and primary connection indicators.
  * Network diagnostics now stay aligned with the active access point.
  * Prevented overlapping refresh activity that could cause delayed or inconsistent updates.
  * Notifications now expire reliably after three seconds.

* **Usability**
  * Refresh frequency is configurable, with a default interval of one second and a minimum of 250 milliseconds.
  * Added documentation for the refresh interval setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->