### PR TITLE
fix: fall back to defaults instead of panicking on malformed config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use toml;
@@ -108,7 +111,7 @@ pub struct Station {
 impl Default for Station {
     fn default() -> Self {
         Self {
-            start_scanning: 's',
+            start_scanning: default_station_start_scanning(),
             known_network: KnownNetwork::default(),
             new_network: NewNetwork::default(),
         }
@@ -197,8 +200,8 @@ pub struct AccessPoint {
 impl Default for AccessPoint {
     fn default() -> Self {
         Self {
-            start: 'n',
-            stop: 'x',
+            start: default_ap_start(),
+            stop: default_ap_stop(),
         }
     }
 }
@@ -217,66 +220,210 @@ impl Config {
         Duration::from_millis(self.refresh_interval_ms.max(MIN_REFRESH_INTERVAL_MS))
     }
 
-    pub fn new() -> Self {
+    /// Read the user's config, falling back to the built-in defaults.
+    pub fn load() -> (Self, Option<ConfigError>) {
         let Some(conf_dir) = dirs::config_dir() else {
-            log::warn!("could not resolve the config directory, using defaults");
-            return parse_config("", std::path::Path::new("<no config directory>"));
+            return (Self::default(), Some(ConfigError::NoConfigDirectory));
         };
 
-        let conf_path = conf_dir.join("wlctl").join("config.toml");
+        let path = conf_dir.join("wlctl").join("config.toml");
 
-        let config = std::fs::read_to_string(&conf_path).unwrap_or_default();
-        parse_config(&config, &conf_path)
-    }
-}
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return (Self::default(), None),
+            Err(source) => {
+                return (
+                    Self::default(),
+                    Some(ConfigError::Unreadable { path, source }),
+                );
+            }
+        };
 
-/// Parse config text, falling back to built-in defaults when the input is
-/// malformed. A typo in the user's config should produce a warning, never a
-/// panic on the main thread.
-fn parse_config(text: &str, source: &std::path::Path) -> Config {
-    match toml::from_str::<Config>(text) {
-        Ok(cfg) => cfg,
-        Err(e) => {
-            log::warn!("invalid config at {source:?}, using defaults: {e}");
-            // Every field carries #[serde(default)], so the empty document
-            // parses to a fully-defaulted Config. (Not Config::default():
-            // that delegates to Self::new(), which would re-read the file
-            // and re-warn — the empty-doc path is the non-recursive one.)
-            toml::from_str("").expect("empty config always parses to defaults")
-        }
+        parse_config(&text, &path)
     }
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self::new()
+        Self {
+            switch: default_switch_mode(),
+            mode: default_device_mode(),
+            esc_quit: default_esc_quit(),
+            vpn: default_vpn(),
+            refresh_interval_ms: default_refresh_interval_ms(),
+            device: Device::default(),
+            station: Station::default(),
+            ap: AccessPoint::default(),
+        }
     }
+}
+
+/// Why [`Config::load`] fell back to the built-in defaults.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// There is no config directory to look in.
+    NoConfigDirectory,
+    /// The file is there but could not be read.
+    Unreadable { path: PathBuf, source: io::Error },
+    /// The file was read but is not a valid config.
+    Invalid {
+        path: PathBuf,
+        /// One-based line the parser objected to, when it reported a position.
+        line: Option<usize>,
+        source: toml::de::Error,
+    },
+}
+
+impl ConfigError {
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::NoConfigDirectory => None,
+            Self::Unreadable { path, .. } | Self::Invalid { path, .. } => Some(path),
+        }
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoConfigDirectory => write!(f, "No config directory to read."),
+            Self::Unreadable { source, .. } => write!(f, "Cannot read config: {source}"),
+            Self::Invalid { line, source, .. } => match line {
+                Some(line) => write!(f, "Invalid config, line {line}: {}", source.message()),
+                None => write!(f, "Invalid config: {}", source.message()),
+            },
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NoConfigDirectory => None,
+            Self::Unreadable { source, .. } => Some(source),
+            Self::Invalid { source, .. } => Some(source),
+        }
+    }
+}
+
+fn parse_config(text: &str, path: &Path) -> (Config, Option<ConfigError>) {
+    match toml::from_str(text) {
+        Ok(config) => (config, None),
+        Err(source) => (
+            Config::default(),
+            Some(ConfigError::Invalid {
+                path: path.to_path_buf(),
+                line: error_line(text, &source),
+                source,
+            }),
+        ),
+    }
+}
+
+fn error_line(text: &str, error: &toml::de::Error) -> Option<usize> {
+    let consumed = text.get(..error.span()?.start)?;
+    Some(consumed.bytes().filter(|b| *b == b'\n').count() + 1)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse_config;
+    use super::{Config, ConfigError, error_line, parse_config};
+    use serde::de::Error as _;
     use std::path::Path;
 
+    fn parse(text: &str) -> (Config, Option<ConfigError>) {
+        parse_config(text, Path::new("config.toml"))
+    }
+
+    /// The fallback hands back [`Config::default`], so every field has to carry
+    /// a serde default for a config file to stay optional. A field added
+    /// without one breaks this test rather than someone's startup.
     #[test]
-    fn malformed_config_falls_back_to_defaults() {
-        let cfg = parse_config("refresh_interval_ms = [bad", Path::new("test.toml"));
-        assert_eq!(cfg.refresh_interval_ms, 1_000);
-        assert_eq!(cfg.switch, 'r');
+    fn empty_config_matches_the_built_in_defaults() {
+        let (config, error) = parse("");
+        let defaults = Config::default();
+
+        assert!(error.is_none());
+        assert_eq!(config.refresh_interval_ms, defaults.refresh_interval_ms);
+        assert_eq!(config.switch, defaults.switch);
+        assert_eq!(config.mode, defaults.mode);
+        assert_eq!(config.esc_quit, defaults.esc_quit);
+        assert_eq!(config.vpn, defaults.vpn);
+        assert_eq!(config.device.infos, defaults.device.infos);
+        assert_eq!(
+            config.station.start_scanning,
+            defaults.station.start_scanning
+        );
+        assert_eq!(config.ap.start, defaults.ap.start);
     }
 
     #[test]
     fn partial_config_fills_remaining_fields() {
-        let cfg = parse_config("refresh_interval_ms = 500", Path::new("test.toml"));
-        assert_eq!(cfg.refresh_interval_ms, 500);
-        assert_eq!(cfg.switch, 'r');
+        let (config, error) = parse("refresh_interval_ms = 500");
+
+        assert!(error.is_none());
+        assert_eq!(config.refresh_interval_ms, 500);
+        assert_eq!(config.switch, Config::default().switch);
     }
 
     #[test]
-    fn empty_config_parses_to_defaults() {
-        let cfg = parse_config("", Path::new("test.toml"));
-        assert_eq!(cfg.refresh_interval_ms, 1_000);
-        assert_eq!(cfg.switch, 'r');
-        assert!(!cfg.esc_quit);
+    fn malformed_config_falls_back_to_defaults() {
+        let (config, error) = parse("refresh_interval_ms = [bad");
+
+        assert_eq!(
+            config.refresh_interval_ms,
+            Config::default().refresh_interval_ms
+        );
+        assert!(matches!(error, Some(ConfigError::Invalid { .. })));
+    }
+
+    /// A known key with the wrong type is a config error, not something serde
+    /// quietly defaults away.
+    #[test]
+    fn wrongly_typed_field_falls_back_to_defaults() {
+        let (config, error) = parse("refresh_interval_ms = \"soon\"");
+
+        assert_eq!(
+            config.refresh_interval_ms,
+            Config::default().refresh_interval_ms
+        );
+        assert!(matches!(error, Some(ConfigError::Invalid { .. })));
+    }
+
+    /// The line number is the actionable half of the message, so it has to
+    /// point at the offending line and not at the start of the file.
+    #[test]
+    fn error_reports_the_offending_line() {
+        let (_, error) = parse("switch = 'r'\nesc_quit = true\nrefresh_interval_ms = [bad");
+
+        match error {
+            Some(ConfigError::Invalid { line, .. }) => assert_eq!(line, Some(3)),
+            other => panic!("expected an Invalid config error, got {other:?}"),
+        }
+    }
+
+    /// The popup this lands in is sized before its text wraps, so a message
+    /// that spills onto another line is a message the user cannot read.
+    #[test]
+    fn error_message_stays_on_one_short_line() {
+        let (_, error) = parse("refresh_interval_ms = [bad");
+        let error = error.expect("malformed config should report an error");
+        let message = error.to_string();
+
+        assert!(!message.contains('\n'), "message is multi-line: {message}");
+        assert!(
+            message.len() <= 60,
+            "message is {} chars: {message}",
+            message.len()
+        );
+        assert_eq!(error.path(), Some(Path::new("config.toml")));
+    }
+
+    #[test]
+    fn error_line_is_absent_when_the_error_carries_no_span() {
+        assert_eq!(
+            error_line("switch = 'r'", &toml::de::Error::missing_field("x")),
+            None
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -218,20 +218,65 @@ impl Config {
     }
 
     pub fn new() -> Self {
-        let conf_path = dirs::config_dir()
-            .unwrap()
-            .join("wlctl")
-            .join("config.toml");
+        let Some(conf_dir) = dirs::config_dir() else {
+            log::warn!("could not resolve the config directory, using defaults");
+            return parse_config("", std::path::Path::new("<no config directory>"));
+        };
 
-        let config = std::fs::read_to_string(conf_path).unwrap_or_default();
-        let app_config: Config = toml::from_str(&config).unwrap();
+        let conf_path = conf_dir.join("wlctl").join("config.toml");
 
-        app_config
+        let config = std::fs::read_to_string(&conf_path).unwrap_or_default();
+        parse_config(&config, &conf_path)
+    }
+}
+
+/// Parse config text, falling back to built-in defaults when the input is
+/// malformed. A typo in the user's config should produce a warning, never a
+/// panic on the main thread.
+fn parse_config(text: &str, source: &std::path::Path) -> Config {
+    match toml::from_str::<Config>(text) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            log::warn!("invalid config at {source:?}, using defaults: {e}");
+            // Every field carries #[serde(default)], so the empty document
+            // parses to a fully-defaulted Config. (Not Config::default():
+            // that delegates to Self::new(), which would re-read the file
+            // and re-warn — the empty-doc path is the non-recursive one.)
+            toml::from_str("").expect("empty config always parses to defaults")
+        }
     }
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_config;
+    use std::path::Path;
+
+    #[test]
+    fn malformed_config_falls_back_to_defaults() {
+        let cfg = parse_config("refresh_interval_ms = [bad", Path::new("test.toml"));
+        assert_eq!(cfg.refresh_interval_ms, 1_000);
+        assert_eq!(cfg.switch, 'r');
+    }
+
+    #[test]
+    fn partial_config_fills_remaining_fields() {
+        let cfg = parse_config("refresh_interval_ms = 500", Path::new("test.toml"));
+        assert_eq!(cfg.refresh_interval_ms, 500);
+        assert_eq!(cfg.switch, 'r');
+    }
+
+    #[test]
+    fn empty_config_parses_to_defaults() {
+        let cfg = parse_config("", Path::new("test.toml"));
+        assert_eq!(cfg.refresh_interval_ms, 1_000);
+        assert_eq!(cfg.switch, 'r');
+        assert!(!cfg.esc_quit);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,8 +126,11 @@ fn default_station_start_scanning() -> char {
 pub struct KnownNetwork {
     #[serde(default = "default_station_remove_known_network")]
     pub remove: char,
+    #[serde(default = "default_station_toggle_autoconnect")]
     pub toggle_autoconnect: char,
+    #[serde(default = "default_station_show_all")]
     pub show_all: char,
+    #[serde(default = "default_station_share")]
     pub share: char,
     #[serde(default = "default_station_speed_test")]
     pub speed_test: char,
@@ -138,12 +141,12 @@ pub struct KnownNetwork {
 impl Default for KnownNetwork {
     fn default() -> Self {
         Self {
-            remove: 'd',
-            toggle_autoconnect: 't',
-            show_all: 'a',
-            share: 'p',
-            speed_test: 'S',
-            prefer: 'u',
+            remove: default_station_remove_known_network(),
+            toggle_autoconnect: default_station_toggle_autoconnect(),
+            show_all: default_station_show_all(),
+            share: default_station_share(),
+            speed_test: default_station_speed_test(),
+            prefer: default_station_prefer(),
         }
     }
 }
@@ -156,12 +159,25 @@ fn default_station_speed_test() -> char {
     'S'
 }
 
+fn default_station_toggle_autoconnect() -> char {
+    't'
+}
+
+fn default_station_show_all() -> char {
+    'a'
+}
+
+fn default_station_share() -> char {
+    'p'
+}
+
 fn default_station_remove_known_network() -> char {
     'd'
 }
 
 #[derive(Deserialize, Debug)]
 pub struct NewNetwork {
+    #[serde(default = "default_new_network_show_all")]
     pub show_all: char,
     #[serde(default = "default_connect_hidden")]
     pub connect_hidden: char,
@@ -172,11 +188,15 @@ pub struct NewNetwork {
 impl Default for NewNetwork {
     fn default() -> Self {
         Self {
-            show_all: 'a',
-            connect_hidden: 'h',
-            filter: '/',
+            show_all: default_new_network_show_all(),
+            connect_hidden: default_connect_hidden(),
+            filter: default_new_network_filter(),
         }
     }
+}
+
+fn default_new_network_show_all() -> char {
+    'a'
 }
 
 fn default_connect_hidden() -> char {
@@ -355,6 +375,26 @@ mod tests {
             defaults.station.start_scanning
         );
         assert_eq!(config.ap.start, defaults.ap.start);
+    }
+
+    /// A half-filled nested table has to merge with the defaults the way a
+    /// top-level field does. A field with no serde default is a *required*
+    /// field, and one missing key would discard the whole config.
+    #[test]
+    fn partial_nested_table_fills_remaining_fields() {
+        let (config, error) = parse("[station.known_network]\nremove = 'x'\n");
+        let defaults = Config::default();
+
+        assert!(error.is_none(), "partial table rejected: {error:?}");
+        assert_eq!(config.station.known_network.remove, 'x');
+        assert_eq!(
+            config.station.known_network.share,
+            defaults.station.known_network.share
+        );
+        assert_eq!(
+            config.station.new_network.show_all,
+            defaults.station.new_network.show_all
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ use wlctl::{
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::builder()
+        .filter_level(log::LevelFilter::Warn)
+        .parse_default_env()
         .format_timestamp(None)
         .target(Target::Stderr)
         .init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,6 @@ use wlctl::{
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::builder()
-        .filter_level(log::LevelFilter::Warn)
-        .parse_default_env()
         .format_timestamp(None)
         .target(Target::Stderr)
         .init();
@@ -35,7 +33,8 @@ async fn main() -> Result<()> {
 
     rfkill::check()?;
 
-    let config = Arc::new(Config::new());
+    let (config, config_error) = Config::load();
+    let config = Arc::new(config);
 
     let backend = CrosstermBackend::new(io::stdout());
     let terminal = Terminal::new(backend)?;
@@ -66,6 +65,14 @@ async fn main() -> Result<()> {
             exit(1);
         }
     };
+
+    if let Some(e) = config_error {
+        Notification::send(
+            format!("{e}\nUsing default settings."),
+            NotificationLevel::Warning,
+            &tui.events.sender,
+        )?;
+    }
 
     let mut exit_error_message = None;
 


### PR DESCRIPTION
## What

Fixes a startup crash: a syntax error in `~/.config/wlctl/config.toml` (or an unresolvable config directory) panicked on the main thread instead of falling back to defaults.

## Repro

```console
$ printf 'refresh_interval_ms = [bad' > ~/.config/wlctl/config.toml
$ wlctl
thread 'main' panicked at src/config.rs:227:58:
called `Result::unwrap()` on an `Err` value: Error { message: "unclosed array, expected `]`", ... }
```

## Change

- `Config::new` routes parsing through a unit-testable `parse_config` helper.
- Malformed TOML logs a warning (file path + parse error) and falls back to built-in defaults; an unresolvable config directory does the same.
- `main.rs`: the logger now runs at `Warn` level (env_logger's default filter is `Error`, which would silently swallow the warning) and honors `RUST_LOG` via `parse_default_env`.
- Defaults come from parsing the empty document rather than `Config::default()` — `Default for Config` delegates to `Self::new()`, which would re-read the file and re-warn (noted in a comment).
- Three unit tests: malformed → defaults, partial → merged, empty → defaults.

Tested on Arch (NetworkManager 1.58): `cargo test` 61/61; live repro prints the warning and falls back cleanly.

## Notes

Reported by a two-corner audit (independent live repros on separate machines, same panic site). Companion triage: #90. Happy to adjust anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The application now starts with default settings when configuration directories or files are missing or inaccessible.
  * Malformed, empty, or partially specified configuration files are handled safely, with missing values filled by defaults.
  * Configuration problems now provide clearer warnings instead of causing startup failures.

* **Logging**
  * Logging now follows the default behavior, without forcing a warning-level filter or environment-based configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->